### PR TITLE
Optimize Background Shader Math and Refine Input Buffers

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -42,7 +42,10 @@ export default class Controller {
   bufferedActionTime: number = 0;
   bufferedMoveAction: Action | null = null;
   bufferedMoveActionTime: number = 0;
-  readonly BUFFER_WINDOW: number = 120; // ms - Snappier jump buffer
+  // Split buffer windows for better input precision:
+  // Movement is forgiving (120ms) but rotation is tighter (60ms) to prevent double-rotations
+  readonly MOVE_BUFFER_WINDOW: number = 120; // ms - Snappier jump buffer
+  readonly ROTATE_BUFFER_WINDOW: number = 60; // ms - Tighter rotation buffer
 
   // Mapping from physical key codes to logical actions
   keyMap: { [key: string]: Action } = {
@@ -685,7 +688,7 @@ export default class Controller {
 
   private processBufferedAction(currentTime: number): void {
       if (this.bufferedMoveAction) {
-          if (currentTime - this.bufferedMoveActionTime > this.BUFFER_WINDOW) {
+          if (currentTime - this.bufferedMoveActionTime > this.MOVE_BUFFER_WINDOW) {
               this.bufferedMoveAction = null;
           } else {
               let moveSuccess = false;
@@ -707,8 +710,12 @@ export default class Controller {
 
       if (!this.bufferedAction) return;
 
+      // Determine correct buffer window for the buffered action
+      const isRotate = this.bufferedAction === 'rotateCW' || this.bufferedAction === 'rotateCCW';
+      const bufferWindow = isRotate ? this.ROTATE_BUFFER_WINDOW : this.MOVE_BUFFER_WINDOW;
+
       // Clear buffer if it's too old
-      if (currentTime - this.bufferedActionTime > this.BUFFER_WINDOW) {
+      if (currentTime - this.bufferedActionTime > bufferWindow) {
           this.bufferedAction = null;
           return;
       }

--- a/src/webgpu/shaders/background.ts
+++ b/src/webgpu/shaders/background.ts
@@ -56,7 +56,8 @@ export const BackgroundShaders = () => {
           // Warps the UVs towards the center as level increases
           if (levelFactor > 0.0 || warpSurge > 0.0) {
               let center = vec2<f32>(0.5, 0.5);
-              let dist = distance(uv, center);
+              var centered = uv - center;
+
               // JUICE: Increased warp strength for higher levels
               // Stronger wobble at high levels
               let wobble = sin(uniforms.time * (2.0 + levelFactor * 5.0));
@@ -66,14 +67,19 @@ export const BackgroundShaders = () => {
                   let angle = warpSurge * 0.1 * sin(time * 5.0);
                   let c = cos(angle);
                   let s = sin(angle);
-                  let centered = uv - center;
-                  uv = center + vec2<f32>(centered.x * c - centered.y * s, centered.x * s + centered.y * c);
+                  // Apply rotation to the centered vector
+                  centered = vec2<f32>(centered.x * c - centered.y * s, centered.x * s + centered.y * c);
+                  uv = center + centered;
               }
 
               // Smoothed and clamped warp strength to prevent nausea
               // BOOSTED: Increased max warp
               let warpStrength = clamp((levelFactor * 0.5 + warpSurge * 0.25) * wobble, -0.4, 0.4);
-              uv -= normalize(uv - center) * warpStrength * dist * dist; // Quadratic warp for "tunnel" feel
+
+              // OPTIMIZATION: Avoid normalize() and distance() to save ALU cycles
+              // normalize(centered) * dist * dist = (centered / dist) * dist^2 = centered * dist
+              let dist = length(centered);
+              uv -= centered * (warpStrength * dist); // Quadratic warp for "tunnel" feel
           }
 
           // OPTIMIZED: Dual-layer parallax starfield


### PR DESCRIPTION
This PR introduces weekly performance optimizations and game-feel polish.

**Optimizations:**
- Replaced `normalize()` and `distance()` in `src/webgpu/shaders/background.ts` with direct vector mathematics, reducing ALU overhead for the hyperspace tunnel effect.

**Game Feel:**
- Addressed precision issues during intense play by splitting the input jump buffer in `src/controller.ts`. Rotation inputs now use a tighter 60ms window to prevent double-rotations, while movement retains the forgiving 120ms window.

---
*PR created automatically by Jules for task [5971126025535234014](https://jules.google.com/task/5971126025535234014) started by @ford442*