### PR TITLE
perf: optimize GC in WebGPU update loops and polish input buffers

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -44,7 +44,7 @@ export default class Controller {
   bufferedMoveActionTime: number = 0;
   // Split buffer windows for better input precision:
   // Movement is forgiving (120ms) but rotation is tighter (60ms) to prevent double-rotations
-  readonly MOVE_BUFFER_WINDOW: number = 80; // ms - Snappier jump buffer
+  readonly MOVE_BUFFER_WINDOW: number = 120; // ms - Forgiving movement
   readonly ROTATE_BUFFER_WINDOW: number = 60; // ms - Tighter rotation buffer
 
   // Mapping from physical key codes to logical actions

--- a/src/webgpu/bloomSystem.ts
+++ b/src/webgpu/bloomSystem.ts
@@ -1,3 +1,9 @@
+interface BloomSystem {
+  _thresholdData?: Float32Array;
+  _blurData?: Float32Array;
+  _upsampleData?: Float32Array;
+  _compositeData?: Float32Array;
+}
 /**
  * BloomSystem - Professional Multi-Pass Bloom Effect for WebGPU
  *
@@ -370,13 +376,14 @@ export class BloomSystem {
    */
   private updateUniforms(): void {
     // Threshold uniforms: threshold, knee, intensity, scatter
-    const thresholdData = new Float32Array([
+    if(!this._thresholdData) this._thresholdData = new Float32Array(4);
+    this._thresholdData.set([
       this.params.threshold,
       this.params.knee,
       this.params.intensity,
       this.params.scatter
     ]);
-    this.device.queue.writeBuffer(this.thresholdUniformBuffer, 0, thresholdData);
+    this.device.queue.writeBuffer(this.thresholdUniformBuffer, 0, this._thresholdData);
     
     // Blur uniforms: texelSize (vec2), mipLevel (f32), padding (f32)
     const mipSizes = [
@@ -386,34 +393,37 @@ export class BloomSystem {
     ];
     
     for (let i = 0; i < BLOOM_MIP_LEVELS; i++) {
-      const blurData = new Float32Array([
+      if(!this._blurData) this._blurData = new Float32Array(4);
+      this._blurData.set([
         1.0 / mipSizes[i].w,
         1.0 / mipSizes[i].h,
         i,
         0.0  // padding
       ]);
-      this.device.queue.writeBuffer(this.blurUniformBuffers[i], 0, blurData);
+      this.device.queue.writeBuffer(this.blurUniformBuffers[i], 0, this._blurData);
     }
     
     // Upsample uniforms: scatter, intensity, clamp, mipLevel
     for (let i = 0; i < BLOOM_MIP_LEVELS; i++) {
-      const upsampleData = new Float32Array([
+      if(!this._upsampleData) this._upsampleData = new Float32Array(4);
+      this._upsampleData.set([
         this.params.scatter,
         this.params.intensity,
         this.params.clamp,
         i
       ]);
-      this.device.queue.writeBuffer(this.upsampleUniformBuffers[i], 0, upsampleData);
+      this.device.queue.writeBuffer(this.upsampleUniformBuffers[i], 0, this._upsampleData);
     }
     
     // Composite uniforms: intensity, clamp, padding x2
-    const compositeData = new Float32Array([
+    if(!this._compositeData) this._compositeData = new Float32Array(4);
+    this._compositeData.set([
       this.params.intensity,
       this.params.clamp,
       0.0,
       0.0
     ]);
-    this.device.queue.writeBuffer(this.compositeUniformBuffer, 0, compositeData);
+    this.device.queue.writeBuffer(this.compositeUniformBuffer, 0, this._compositeData);
   }
   
   /**

--- a/src/webgpu/geometry.ts
+++ b/src/webgpu/geometry.ts
@@ -116,8 +116,9 @@ export const CubeData = () => {
   return { positions, normals, uvs };
 };
 
+let _fullScreenQuadData: Float32Array;
 export const FullScreenQuadData = () => {
-    const positions = new Float32Array([
+    if (!_fullScreenQuadData) _fullScreenQuadData = new Float32Array([
         -1.0, -1.0, 0.0,
          1.0, -1.0, 0.0,
         -1.0,  1.0, 0.0,
@@ -125,14 +126,16 @@ export const FullScreenQuadData = () => {
          1.0, -1.0, 0.0,
          1.0,  1.0, 0.0,
     ]);
-    return { positions };
+    return { positions: _fullScreenQuadData };
 };
 
+let _gridDataPositions: Float32Array;
 export const GridData = () => {
     // 9 vertical lines * 2 points * 3 components = 54
     // 19 horizontal lines * 2 points * 3 components = 114
     // Total = 168
-    const positions = new Float32Array(168);
+    if (!_gridDataPositions) _gridDataPositions = new Float32Array(168);
+    const positions = _gridDataPositions;
     let index = 0;
 
     const yTop = 1.1;

--- a/src/webgpu/viewFrostedGlass.ts
+++ b/src/webgpu/viewFrostedGlass.ts
@@ -76,6 +76,8 @@ export async function initFrostedGlassBackboard(
 /**
  * Update frosted glass uniforms and bind group.
  */
+let _frostedGlassUniformData: Float32Array;
+
 export function updateFrostedGlassUniforms(
   device: GPUDevice,
   pipeline: GPURenderPipeline,
@@ -90,7 +92,8 @@ export function updateFrostedGlassUniforms(
   Matrix.mat4.translate(modelMatrix, modelMatrix, [0, 0, -1.0]);
   Matrix.mat4.scale(modelMatrix, modelMatrix, [12.0, 24.0, 1.0]);
 
-  const uniformData = new Float32Array(40);
+  if (!_frostedGlassUniformData) _frostedGlassUniformData = new Float32Array(40);
+  const uniformData = _frostedGlassUniformData;
   uniformData.set(vpMatrix, 0);
   uniformData.set(modelMatrix as Float32Array, 16);
   const tint = borderColor || [0.5, 0.5, 0.5, 0.3];

--- a/src/webgpu/viewTextures.ts
+++ b/src/webgpu/viewTextures.ts
@@ -78,6 +78,8 @@ export function generateMipmaps(
 /**
  * Create a solid white 1x1 fallback texture.
  */
+let _solidFallbackData: Uint8Array;
+
 export function createSolidFallbackTexture(device: GPUDevice): GPUTexture {
   const texture = device.createTexture({
     size: [1, 1, 1],
@@ -86,7 +88,7 @@ export function createSolidFallbackTexture(device: GPUDevice): GPUTexture {
   });
   device.queue.writeTexture(
     { texture },
-    new Uint8Array([255, 255, 255, 255]),
+    _solidFallbackData || (_solidFallbackData = new Uint8Array([255, 255, 255, 255])),
     { bytesPerRow: 4 },
     [1, 1, 1]
   );


### PR DESCRIPTION
This PR addresses performance regressions caused by excessive garbage collection during rendering loops and refines movement game feel.

1. Graphical Optimizations:
   - Extracted `Float32Array` instantiations out of tight update loops in `bloomSystem.ts` and `viewFrostedGlass.ts`, pre-allocating them instead.
   - Refactored `geometry.ts` and `viewTextures.ts` to use cached buffers for grid/fullscreen geometry and fallback textures.

2. Game Feel Polish:
   - Adjusted `MOVE_BUFFER_WINDOW` in `controller.ts` from 80ms to 120ms for better jump buffer leniency.
   - Verified that `Math.pow` calculations in `controller.ts` (gravity) and reactive music correctly scale the Tetris speed and pitch progression.

All tests passed successfully locally (`npm test`).

---
*PR created automatically by Jules for task [6520708889697670444](https://jules.google.com/task/6520708889697670444) started by @ford442*