### PR TITLE
Optimize WebGPU Texture Sampling for Block Art

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -465,8 +465,8 @@ export default class View {
     this.ctxWebGPU.configure({ device: this.device, format: presentationFormat, alphaMode: 'premultiplied' });
 
     this.blockSampler = this.device.createSampler({
-      magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear',
-      addressModeU: 'repeat', addressModeV: 'repeat', maxAnisotropy: 16,
+      magFilter: 'nearest', minFilter: 'nearest', mipmapFilter: 'nearest',
+      addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge',
     });
 
     try {


### PR DESCRIPTION
Updates the `blockSampler` settings in `src/viewWebGPU.ts` to use nearest-neighbor filtering and clamp-to-edge addressing. This ensures sharp, crisp pixel rendering and prevents color bleeding from adjacent tiles in the texture atlas, optimizing the visual quality for a blocky game style.

---
*PR created automatically by Jules for task [3969586496432784267](https://jules.google.com/task/3969586496432784267) started by @ford442*