### PR TITLE
fix: eliminate double-bloom washout and redundant frame uniform call

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -828,8 +828,6 @@ export default class View {
         this.particleSystem.clearPending();
     }
 
-    // Write all per-frame uniform buffers (delegated to viewUniforms.ts)
-    updateFrameUniforms(this, dt, time);
     // Compute uniforms
     const swParams = this.visualEffects.getShockwaveParams();
     const swCenter = this.visualEffects.shockwaveCenter;
@@ -958,12 +956,15 @@ export default class View {
     this._postProcessParams.level = this.visualEffects.currentLevel;
     this._postProcessParams.warpSurge = this.visualEffects.warpSurge;
     this._postProcessParams.enableFXAA = this.useEnhancedPostProcess ? 1.0 : 0.0;
-    this._postProcessParams.enableBloom = (this.useEnhancedPostProcess && this.bloomEnabled) ? 1.0 : 0.0;
+    // When multi-pass bloom is active it handles bloom exclusively — disable the
+    // in-shader 13-tap bloom to avoid double-blooming that washes out the board.
+    const inShaderBloom = this.useEnhancedPostProcess && this.bloomEnabled && !this.useMultiPassBloom;
+    this._postProcessParams.enableBloom = inShaderBloom ? 1.0 : 0.0;
     this._postProcessParams.enableFilmGrain = 1.0;
     this._postProcessParams.enableCRT = 0.0;
     this._postProcessParams.bloomIntensity = this.bloomIntensity;
     this._postProcessParams.bloomThreshold = 0.35;
-    this._postProcessParams.materialAwareBloom = this.useEnhancedPostProcess ? 1.0 : 0.0;
+    this._postProcessParams.materialAwareBloom = (this.useEnhancedPostProcess && !this.useMultiPassBloom) ? 1.0 : 0.0;
     this._postProcessParams.screenResolution[0] = this.canvasWebGPU.width;
     this._postProcessParams.screenResolution[1] = this.canvasWebGPU.height;
 

--- a/src/webgpu/viewUniforms.ts
+++ b/src/webgpu/viewUniforms.ts
@@ -145,12 +145,13 @@ export function updateFrameUniforms(view: any, dt: number, time: number): FrameU
     level: view.visualEffects.currentLevel,
     warpSurge: view.visualEffects.warpSurge,
     enableFXAA: view.useEnhancedPostProcess ? 1.0 : 0.0,
-    enableBloom: (view.useEnhancedPostProcess && view.bloomEnabled) ? 1.0 : 0.0,
+    // Disable in-shader bloom when multi-pass bloom handles it (avoids double-bloom washout)
+    enableBloom: (view.useEnhancedPostProcess && view.bloomEnabled && !view.useMultiPassBloom) ? 1.0 : 0.0,
     enableFilmGrain: 1.0,
     enableCRT: 0.0,
     bloomIntensity: view.bloomIntensity,
     bloomThreshold: 0.35,
-    materialAwareBloom: view.useEnhancedPostProcess ? 1.0 : 0.0,
+    materialAwareBloom: (view.useEnhancedPostProcess && !view.useMultiPassBloom) ? 1.0 : 0.0,
     screenResolution: [view.canvasWebGPU.width, view.canvasWebGPU.height],
   });
   device.queue.writeBuffer(view.postProcessUniformBuffer, 0, ppUniforms);


### PR DESCRIPTION
When both useMultiPassBloom and bloomEnabled are true, the post-process shader was running its own 13-tap material-aware bloom (enableBloom=1.0) and THEN the multi-pass bloom pyramid ran on top of that already-bloomed intermediate texture. The compounded bloom completely washed out the game board — visible as the "bloom ON" blurry screenshot where all block detail was obliterated.

Fix: when useMultiPassBloom is active, force enableBloom=0 and materialAwareBloom=0 in the post-process uniform so the in-shader bloom pass is skipped. The multi-pass BloomSystem becomes the sole bloom source, receiving a clean (non-pre-bloomed) post-processed image as input.

Also remove the spurious first updateFrameUniforms() call at the top of render(). It was called twice — the first call discarded its returned commandEncoder, but still dispatched GPU compute work for particles, causing every particle simulation step to run twice per frame.

https://claude.ai/code/session_015onZJkkxretB1zGLXrrTtk