### PR TITLE
Weekly optimizations: block texture mapping and shader ALU

### DIFF
--- a/jules_plan.md
+++ b/jules_plan.md
@@ -43,3 +43,9 @@ This document summarizes the changes applied to the Tetris WebGPU codebase to en
 **4. Additional Optimizations from this week's iteration:**
    - Further reduced ALU usage in the main shader by replacing `distance()` calculation with a cheaper `length()` vector operation.
    - Widened block texture mapping (`textureScale` from 0.95 to 0.98 in `src/webgpu/geometry.ts`) to reveal sharper marble and inner-tile detail while maintaining edge safety for texture atlases.
+
+**5. Additional Block Rendering Improvements:**
+   - Widened block texture mapping (`textureScale` from 0.98 to 0.99 in `src/webgpu/geometry.ts`) to reveal even sharper marble and inner-tile detail while still safely avoiding edge bleeding from texture atlases.
+
+**6. Shader ALU Optimization (Continued):**
+   - Further reduced ALU usage in `src/webgpu/shaders/postProcess.ts` by replacing `distance(uv, center)` with `length(uv - center)`, which is typically faster and completely removes the last unoptimized `distance` function call from the shaders.

--- a/src/webgpu/geometry.ts
+++ b/src/webgpu/geometry.ts
@@ -21,7 +21,7 @@ export const CubeData = () => {
 
   // Keep the face UVs normalized because the shader now samples
   // a single tile from the texture atlas for each block face.
-  const textureScale = 0.98; // Zoom in to avoid blurry tile edges
+  const textureScale = 0.99; // Zoom in to avoid blurry tile edges
 
   const pushVertex = (x: number, y: number, z: number, uAxis: string, vAxis: string, uDir: number, vDir: number) => {
     // 1. Clamp to inner box

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -57,7 +57,7 @@ export const PostProcessShaders = () => {
             // Shockwave Logic
             var shockwaveAberration = 0.0;
             if (time > 0.0 && time < 1.0) {
-                let dist = distance(uv, center);
+                let dist = length(uv - center);
                 // NEON BRICKLAYER: Use speed from params.w
                 let speed = max(params.w, 0.1);
                 let radius = time * speed;


### PR DESCRIPTION
This pull request applies weekly graphical optimizations for the WebGPU Tetris project. It enhances texture sampling for blocks by modifying `textureScale` to slightly zoom in and reduce blurry edges without texture bleed. It also completely removes `distance` function usage from shaders to cut down on ALU cycles by replacing it with `length`.

---
*PR created automatically by Jules for task [11797907728457982786](https://jules.google.com/task/11797907728457982786) started by @ford442*