### PR TITLE
Enhance visual feedback and game feel (Neon Bricklayer)

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,7 +3,7 @@ import View from "./viewWebGPU.js";
 import SoundManager from "./sound.js";
 import { TouchControls, TouchAction, addTouchControlStyles } from "./input/touchControls.js";
 
-const DAS = 100; // Delayed Auto Shift (ms) - Slightly faster for improved responsiveness
+const DAS = 80; // Delayed Auto Shift (ms) - Slightly faster for improved responsiveness
 const ARR = 5;  // Auto Repeat Rate (ms) - Very fast but controllable, snappier movement
 const SOFT_DROP_SPEED = 1; // Sonic Drop: Even faster soft drop for instant tactile feedback
 

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -208,7 +208,7 @@ export const EnhancedPostProcessShaders = () => {
             let distFromCenter = sqrt(distFromCenterSq);
             let levelStress = clamp(level / 12.0, 0.0, 1.0);
             let d2 = distFromCenterSq;
-            let vignetteAberration = (d2 * d2) * 0.06;
+            let vignetteAberration = (d2 * d2) * 0.12;
             let levelAberration = levelStress * 0.005 * sin(uniforms.time * 2.0);
             let glitchAberration = glitchStrength * 0.03;
             let totalAberration = vignetteAberration + levelAberration + shockwaveAberration + glitchAberration;

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -258,7 +258,7 @@ export const MaterialAwarePostProcessShaders = () => {
             let distFromCenter = sqrt(distFromCenterSq);
             let levelStress = clamp(level / 12.0, 0.0, 1.0);
             let d2 = distFromCenterSq;
-            let vignetteAberration = (d2 * d2) * 0.04;
+            let vignetteAberration = (d2 * d2) * 0.08;
             let levelAberration = levelStress * 0.003 * sin(uniforms.time * 2.0);
             let glitchAberration = glitchStrength * 0.02;
             let totalAberration = vignetteAberration + levelAberration + shockwaveAberration + glitchAberration;

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -236,7 +236,7 @@ export const PBRBlockShaders = () => {
             // Rim lighting
             let rimPower = (1.0 - NdotV) * (1.0 - NdotV);
             let rimColor = mix(vColor.rgb, vec3f(1.0), metalMask * fUniforms.metallic);
-            finalColor += rimColor * rimPower * 0.1;
+            finalColor += rimColor * rimPower * 0.3;
 
             // Lock tension effect
             let lockPercent = fUniforms.lockPercent;
@@ -258,6 +258,10 @@ export const PBRBlockShaders = () => {
                 let ghostColorFinal = ghostColor + vec3f(0.4, 0.7, 1.0) * (g1 * g1 * g1) * 1.5;
                 return vec4f(ghostColorFinal, 0.35 + scan * 0.2);
             }
+
+            // Subtle emissive pulse
+            let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
+            finalColor += baseColor * emissivePulse * 0.15;
 
             finalColor = acesToneMapping(finalColor);
             let materialAlpha = mix(0.85, 0.98, metalMask);

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -207,10 +207,10 @@ export function triggerImpactEffects(view: any, worldX: number, impactY: number,
   const uvX = 0.5 + (worldX - 10.0) / visibleWidth;
   const uvY = 0.5 - (impactY - camY) / visibleHeight;
 
-  const strength = 0.8 + Math.min(distance * 0.08, 0.7);
-  const width = 0.4 + Math.min(distance * 0.04, 0.5);
+  const strength = 1.2 + Math.min(distance * 0.12, 1.0);
+  const width = 0.6 + Math.min(distance * 0.06, 0.8);
   const aberration = 0.2 + Math.min(distance * 0.03, 0.5);
-  const speed = 3.0 + Math.min(distance * 0.2, 2.0);
+  const speed = 4.0 + Math.min(distance * 0.3, 3.0);
 
   view.visualEffects.triggerShockwave([uvX, uvY], width, strength, aberration, speed);
   view.visualEffects.warpSurge = 0.5 + Math.min(distance * 0.1, 1.0);


### PR DESCRIPTION
Implemented visual feedback and "juice" enhancements as requested by the Neon Bricklayer. The hard drop shockwave is more impactful, chromatic aberration is increased for a retro arcade style, blocks now have a subtle emissive pulse with stronger rim lighting, and input DAS has been reduced to make the game feel snappier.

---
*PR created automatically by Jules for task [10673285161524775846](https://jules.google.com/task/10673285161524775846) started by @ford442*