### PR TITLE
Enhance game juice (additive particles & exponential shake)

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -622,7 +622,7 @@ export default class View {
             ]
         }]},
         fragment: { module: this.device.createShaderModule({ code: particleShader.fragment }), entryPoint: 'main', targets: [{ format: presentationFormat, blend: {
-            color: { srcFactor: 'src-alpha', dstFactor: 'one', operation: 'add' },
+            color: { srcFactor: 'one', dstFactor: 'one', operation: 'add' },
             alpha: { srcFactor: 'one', dstFactor: 'one', operation: 'add' },
         }}]},
         primitive: { topology: 'triangle-list' },
@@ -807,8 +807,8 @@ export default class View {
     let camY = BOARD_WORLD_CENTER_Y + Math.cos(time * 0.3) * 0.25 + 2.0; // Slight downward tilt (+2.0 Y offset)
     const shake = this.visualEffects.getShakeOffset();
 
-    // Smooth Camera Shake Interpolation using fast exponential decay approximation
-    const shakeDecay = 1.0 / (1.0 + clampedDt * 10.0);
+    // Smooth Camera Shake Interpolation using exponential decay
+    const shakeDecay = Math.exp(-clampedDt * 10.0);
     this._shakeOffsetSmoothed.x = shake.x + (this._shakeOffsetSmoothed.x - shake.x) * shakeDecay;
     this._shakeOffsetSmoothed.y = shake.y + (this._shakeOffsetSmoothed.y - shake.y) * shakeDecay;
 

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -51,10 +51,10 @@ export class VisualEffects {
         if (this.lockTimer > 0) this.lockTimer -= dt;
         if (this.lockTimer < 0) this.lockTimer = 0;
 
-        // Exponential decay for smooth game feel (fast algebraic approximation)
-        const decay = 1.0 / (1.0 + dt * 3.0);
-        this.shakeIntensity *= decay;
-        this.aberrationIntensity *= decay;
+        // Exponential decay for smooth game feel (fast algebraic approximation for aberration, true exponential for shake)
+        const aberrationDecay = 1.0 / (1.0 + dt * 3.0);
+        this.shakeIntensity *= Math.exp(-dt * 10.0);
+        this.aberrationIntensity *= aberrationDecay;
 
         // Warp surge decay
         this.warpSurge *= 1.0 / (1.0 + dt * 1.5);


### PR DESCRIPTION
Implemented specific game feel features according to "The Neon Bricklayer" visual log:
1. Replaced algebraic approximations for screen shake with `Math.exp(-dt * 10.0)` to create a snappier, true exponential decay on camera and effect shake.
2. Altered the WebGPU blend target configuration for particles to use `srcFactor: 'one'` (pure additive), making explosions behave like real light.

---
*PR created automatically by Jules for task [18220936178540304291](https://jules.google.com/task/18220936178540304291) started by @ford442*