### PR TITLE
Juice up game feel and visuals

### DIFF
--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -53,7 +53,7 @@ export class VisualEffects {
 
         // Exponential decay for smooth game feel (fast algebraic approximation for aberration, true exponential for shake)
         const aberrationDecay = 1.0 / (1.0 + dt * 3.0);
-        this.shakeIntensity *= Math.exp(-dt * 10.0);
+        this.shakeIntensity *= Math.exp(-dt * 15.0);
         this.aberrationIntensity *= aberrationDecay;
 
         // Warp surge decay

--- a/src/webgpu/shaders/background.ts
+++ b/src/webgpu/shaders/background.ts
@@ -155,8 +155,8 @@ export const BackgroundShaders = () => {
           var neonBlue = uniforms.color3;
 
           // Manual mix for level influence (mix towards red/orange) (ENHANCED)
-          let dangerColor = vec3<f32>(1.0, 0.0, 0.2); // Cyberpunk Red
-          let warningColor = vec3<f32>(1.0, 0.5, 0.0); // Orange
+          let dangerColor = vec3<f32>(1.0, 0.0, 0.0); // Pure chaotic Red
+          let warningColor = vec3<f32>(1.0, 0.2, 0.0); // Aggressive Red-Orange
 
           // Shift aggressively with level
           // Level 0-5: Blue/Cyan -> Purple

--- a/src/webgpu/shaders/main.ts
+++ b/src/webgpu/shaders/main.ts
@@ -177,11 +177,11 @@ export const Shaders = () => {
                 let rimFalloff = 1.0 - max(dot(N, V), 0.0);
                 let rimFalloff2 = rimFalloff * rimFalloff;
                 let rimFalloff4 = rimFalloff2 * rimFalloff2;
-                let rimLight = rimFalloff4 * (15.0 + f32(uniforms.level) * 1.0); // Sharper, brighter rim
+                let rimLight = rimFalloff4 * (30.0 + f32(uniforms.level) * 2.0); // Sharper, brighter rim
                
                 // Color the rim based on piece color for glass, white for metal
                 let rimColor = mix(vColor.rgb * 0.8, vec3<f32>(1.0), metalMask);
-                finalColor += rimColor * rimLight * 0.08;
+                finalColor += rimColor * rimLight * 0.2;
                 // Simple fresnel (needed for ghost piece downstream)
                 // dotNV already computed above for iridescence
                 let fresnelBase = 1.0 - dotNV;

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -238,7 +238,7 @@ export const PBRBlockShaders = () => {
             let rimPower2 = rimPower * rimPower;
             let rimPower4 = rimPower2 * rimPower2;
             let rimColor = mix(vColor.rgb, vec3f(1.0), metalMask * fUniforms.metallic);
-            finalColor += rimColor * rimPower4 * 0.15;
+            finalColor += rimColor * rimPower4 * 0.4;
 
             // Lock tension effect
             let lockPercent = fUniforms.lockPercent;
@@ -263,7 +263,7 @@ export const PBRBlockShaders = () => {
 
             // Amplified emissive pulse for more visible pulsing effect
             let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
-            finalColor += baseColor * emissivePulse * 0.4;
+            finalColor += baseColor * emissivePulse * 0.8;
 
             finalColor = acesToneMapping(finalColor);
             let materialAlpha = mix(0.85, 0.98, metalMask);

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -207,9 +207,9 @@ export function triggerImpactEffects(view: any, worldX: number, impactY: number,
   const uvX = 0.5 + (worldX - 10.0) / visibleWidth;
   const uvY = 0.5 - (impactY - camY) / visibleHeight;
 
-  const strength = 1.5 + Math.min(distance * 0.12, 0.7);
-  const width = 0.8 + Math.min(distance * 0.06, 0.4);
-  const aberration = 0.2 + Math.min(distance * 0.03, 0.5);
+  const strength = 2.5 + Math.min(distance * 0.2, 1.0);
+  const width = 1.2 + Math.min(distance * 0.1, 0.6);
+  const aberration = 0.4 + Math.min(distance * 0.06, 0.8);
   const speed = 5.0 + Math.min(distance * 0.4, 4.0);
 
   view.visualEffects.triggerShockwave([uvX, uvY], width, strength, aberration, speed);
@@ -224,7 +224,7 @@ export function onHardDrop(view: any, x: number, y: number, distance: number, co
   const themeColors = view.currentTheme[colorIdx] || [0.4, 0.8, 1.0];
   const trailColor = [...themeColors, 0.8];
 
-  for (let i = 0; i < distance * 2; i++) {
+  for (let i = 0; i < distance * 4; i++) {
     const r = startRow + i * 0.5;
     const worldY = r * -2.2;
     view.particleSystem.emitParticles(worldX, worldY, 0.0, 12, trailColor);
@@ -233,8 +233,8 @@ export function onHardDrop(view: any, x: number, y: number, distance: number, co
   const impactY = y * -2.2;
   const burstColor = [...themeColors, 1.0];
   view.visualEffects.triggerFlash(0.1);
-  for (let i = 0; i < 150; i++) {
-    const angle = (i / 150) * Math.PI * 2;
+  for (let i = 0; i < 300; i++) {
+    const angle = (i / 300) * Math.PI * 2;
     const speed = 20.0 + Math.random() * 10.0;
     view.particleSystem.emitParticlesRadial(worldX, impactY, 0.0, angle, speed, burstColor);
   }


### PR DESCRIPTION
This change implements the "Juice" and visual spectacle guidelines from "The Neon Bricklayer" persona. It amplifies lighting, hard drop impact particles, screen shake snappiness, and high-level background danger colors to make the game feel more responsive and visually satisfying.

---
*PR created automatically by Jules for task [8070326450928600205](https://jules.google.com/task/8070326450928600205) started by @ford442*