### PR TITLE
perf: Eliminate array GC overhead and unify PBR glass transmission optimizations

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -471,7 +471,8 @@ export default class Game {
       // Create a copy of the blocks array for the active piece, because _tempBlocks will be overwritten in the next rotation
       for (let i = 0; i < this._tempPiece.blocks.length; i++) {
         if (!this.activPiece.blocks[i] || this.activPiece.blocks[i].length !== this._tempPiece.blocks[i].length) {
-            this.activPiece.blocks[i] = new Array(this._tempPiece.blocks[i].length).fill(0);
+            if (!this.activPiece.blocks[i]) this.activPiece.blocks[i] = [];
+            this.activPiece.blocks[i].length = this._tempPiece.blocks[i].length;
         }
         for (let j = 0; j < this._tempPiece.blocks[i].length; j++) {
             this.activPiece.blocks[i][j] = this._tempPiece.blocks[i][j];
@@ -509,7 +510,8 @@ export default class Game {
       // Create a copy of the blocks array for the active piece, because _tempBlocks will be overwritten in the next rotation
       for (let i = 0; i < this._tempPiece.blocks.length; i++) {
         if (!this.activPiece.blocks[i] || this.activPiece.blocks[i].length !== this._tempPiece.blocks[i].length) {
-            this.activPiece.blocks[i] = new Array(this._tempPiece.blocks[i].length).fill(0);
+            if (!this.activPiece.blocks[i]) this.activPiece.blocks[i] = [];
+            this.activPiece.blocks[i].length = this._tempPiece.blocks[i].length;
         }
         for (let j = 0; j < this._tempPiece.blocks[i].length; j++) {
             this.activPiece.blocks[i][j] = this._tempPiece.blocks[i][j];

--- a/src/game/rotation.ts
+++ b/src/game/rotation.ts
@@ -43,7 +43,8 @@ export function rotatePieceBlocks(blocks: number[][], clockwise: boolean, target
     // Ensure inner arrays match length
     for (let i = 0; i < length; i++) {
       if (temp[i].length !== length) {
-        temp[i] = new Array(length).fill(0);
+        temp[i].length = length;
+        for(let j=0; j<length; j++) temp[i][j] = 0;
       }
     }
   }

--- a/src/game/stateProjection.ts
+++ b/src/game/stateProjection.ts
@@ -31,7 +31,7 @@ export function buildPlayfieldProjection({
     // Ensure inner arrays match length
     for (let y = 0; y < playfieldHeight; y++) {
       if (playfield2D[y].length !== playfieldWidth) {
-        playfield2D[y] = new Array(playfieldWidth).fill(0);
+        for(let x=0; x<playfieldWidth; x++){playfield2D[y][x]=0;}
       }
     }
   }

--- a/src/webgpu/shaders/premiumBlocks.ts
+++ b/src/webgpu/shaders/premiumBlocks.ts
@@ -385,11 +385,13 @@ export const PremiumBlockShaders = () => {
                 // Fresnel-based opacity
                 let f = 1.0 - NdotV;
                 let fresnel = f * f * f;
-                transmissionAlpha = mix(max(0.0, 1.0 - transmission * 1.5), 1.0, fresnel);
+                transmissionAlpha = mix(max(0.0, 1.0 - transmission * 1.8), 1.0, fresnel);
                 
                 // Procedural refraction color shift
                 let refractDir = refract(-V, N, 1.0 / ior);
-                refractionColor = proceduralEnvReflect(refractDir, time);
+                let refractionColorBase = proceduralEnvReflect(refractDir, time);
+                let glassTint = mix(vec3<f32>(1.0), vColor.rgb, 0.02);
+                refractionColor = refractionColorBase * glassTint;
                 
                 // Chromatic dispersion at edges
                 if (dispersion > 0.0) {

--- a/src/webgpu/shaders/underwaterBlocks.ts
+++ b/src/webgpu/shaders/underwaterBlocks.ts
@@ -367,7 +367,7 @@ export const UnderwaterBlockShaders = () => {
                 if (transmission > 0.0 && glassMask > 0.1) {
                     let f = 1.0 - NdotV;
                     let fresnel = f * f * f;
-                    let transmissionAlpha = mix(max(0.0, 1.0 - transmission * 1.5), 1.0, fresnel);
+                    let transmissionAlpha = mix(max(0.0, 1.0 - transmission * 1.8), 1.0, fresnel);
                     
                     // Underwater refraction with caustics
                     var refractDir = refract(-V, N, 1.0 / fUniforms.ior);
@@ -377,7 +377,8 @@ export const UnderwaterBlockShaders = () => {
                         refractDir.x += swimDistort;
                     }
                     
-                    let refractionColor = vec3f(0.1, 0.3, 0.5); // Underwater tint
+                    let glassTint = mix(vec3f(1.0), vColor.rgb, 0.02);
+                    var refractionColor = vec3f(0.1, 0.3, 0.5) * glassTint; // Underwater tint
                     refractionColor += causticAdd * 0.3 * glassMask;
                     
                     finalColor = mix(refractionColor, finalColor, transmissionAlpha);


### PR DESCRIPTION
This weekly update continues the progressive optimization pass on the Tetris WebGPU codebase. 

First, it eliminates array allocations (`new Array().fill(0)`) dynamically executing inside the core logic loops (matrix building in `stateProjection.ts`, piece rotation in `rotation.ts`, and deep copying in `game.ts`). Reusing the arrays instead of spawning new instances per-input or per-frame substantially lowers garbage generation and prevents V8 GC pauses from interrupting standard 60 FPS pacing.

Second, it standardizes PBR material parameters across all shader blocks. The optimized glass transmission modifier (`1.8`) and minimal glass tint mix (`0.02`) found inside the main `pbrBlocks.ts` shader have been back-ported into `premiumBlocks.ts` and `underwaterBlocks.ts`, ensuring background transparency visibility behaves identically no matter what theme the user currently has active.

---
*PR created automatically by Jules for task [5618765372138609059](https://jules.google.com/task/5618765372138609059) started by @ford442*