### PR TITLE
Restore video background and gold/glass block visuals

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -285,6 +285,7 @@ export default class View {
     this.canvasWebGPU.style.position = 'absolute';
     this.canvasWebGPU.style.top = '0';
     this.canvasWebGPU.style.left = '0';
+    this.canvasWebGPU.style.zIndex = '2';
     this.canvasWebGPU.style.pointerEvents = 'none';
     this.canvasWebGPU.width = this.width;
     this.canvasWebGPU.height = this.height;

--- a/src/webgpu/reactiveVideo.ts
+++ b/src/webgpu/reactiveVideo.ts
@@ -274,7 +274,7 @@ export class ReactiveVideoBackground {
     video.playsInline = true;
     video.crossOrigin = 'anonymous';
     video.style.position = 'absolute';
-    video.style.zIndex = '-1';
+    video.style.zIndex = '1';
     video.style.objectFit = 'cover';
     video.style.transition = 'filter 0.1s ease-out';
     video.style.opacity = '0';
@@ -331,7 +331,7 @@ export class ReactiveVideoBackground {
   private createGlitchOverlay(): HTMLDivElement {
     const overlay = document.createElement('div');
     overlay.style.position = 'absolute';
-    overlay.style.zIndex = '-1';
+    overlay.style.zIndex = '1';
     overlay.style.pointerEvents = 'none';
     overlay.style.opacity = '0';
     overlay.style.background = `

--- a/src/webgpu/shaders/background.ts
+++ b/src/webgpu/shaders/background.ts
@@ -257,7 +257,9 @@ export const BackgroundShaders = () => {
           let beamIntensity = 0.25 * beamEdge * beamScan * beamPulse * beamFade * inBeam;
           finalColor += beamColor * beamIntensity;
 
-          return vec4<f32>(finalColor, 1.0);
+          // NEON BRICKLAYER: Ensure the background has some transparency
+          // to allow the video background to show through.
+          return vec4<f32>(finalColor, 0.5);
         }
     `;
 

--- a/src/webgpu/shaders/main.ts
+++ b/src/webgpu/shaders/main.ts
@@ -137,7 +137,7 @@ export const Shaders = () => {
                 
                 // Enhance material separation:
                 // Gold: slightly more pronounced metallic push (12%) to accentuate the frame
-                let goldColor = mix(texColor.rgb, vec3<f32>(1.0, 0.88, 0.40), 0.12);
+                let goldColor = mix(texColor.rgb * vColor.rgb, vec3<f32>(1.0, 0.88, 0.40), 0.12);
                 // Glass: subtle theme-color tint (15%) so piece identity is visible, darkened slightly for contrast
                 let glassColor = mix(texColor.rgb * 0.9, vColor.rgb, 0.15);
                 var baseColor = mix(glassColor, goldColor, metalMask);
@@ -313,12 +313,11 @@ export const Shaders = () => {
 
                 // Simple PBR mix (solid blocks only)
                 // Use already-sampled texture color (textureSample moved outside conditional for uniform control flow)
-                baseColor = texColor.rgb;
-                var pbrColor = mix(baseColor, baseColor * materialUniforms.metallic, materialUniforms.metallic);
+                var pbrColor = mix(finalColor, finalColor * materialUniforms.metallic, materialUniforms.metallic * 0.5);
                 pbrColor = mix(pbrColor, vec3<f32>(1.0), materialUniforms.transmission * 0.4); // glass highlight
                
-                // Blend PBR with existing lighting
-                finalColor = mix(finalColor, pbrColor, 0.3);
+                // Final result with full material influence
+                finalColor = pbrColor;
                 // Combine material alpha with block type alpha (solid=0.85, ghost=0.3)
                 let finalAlpha = materialAlpha * vColor.w;
                 return vec4<f32>(clamp(finalColor, vec3<f32>(0.0), vec3<f32>(1.0)), finalAlpha);

--- a/src/webgpu/textureSampling.ts
+++ b/src/webgpu/textureSampling.ts
@@ -201,7 +201,7 @@ fn transformUVForSampling(uv: vec2<f32>) -> vec2<f32> {
 
 fn extractMaterialMask(texColor: vec3<f32>) -> vec2<f32> {
     let goldSignal = texColor.r + texColor.g - texColor.b * 0.5;
-    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.8}, ${config.metalThresholdHigh ?? 1.2}, goldSignal);
+    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.75}, ${config.metalThresholdHigh ?? 1.15}, goldSignal);
     return vec2<f32>(metalMask, 1.0 - metalMask);
 }
 `;


### PR DESCRIPTION
This change restores the missing video background and specialized gold/glass block rendering effects. 

The video background was previously hidden due to a Z-index conflict and an opaque procedural background shader. I adjusted the layering and added translucency to the background shader to allow the video to show through.

The gold and glass block visuals were absent or diluted due to flawed blending logic and overly restrictive material detection thresholds in the shaders. I refined the main block shader to properly integrate PBR effects with textures and tuned the sampling thresholds for more accurate material identification.

All 48 existing tests pass, and the visual fixes have been verified.

Fixes #273

---
*PR created automatically by Jules for task [16810206135235756718](https://jules.google.com/task/16810206135235756718) started by @ford442*