### PR TITLE
feat(graphics): enhance neon bricklayer visuals and game feel

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -45,7 +45,7 @@ export default class Game {
   // Extended Placement (Infinity-like behavior)
   lockResets: number = 0;
   // NEON BRICKLAYER: Verified Infinity Mechanics (15 resets)
-  readonly maxLockResets: number = 25;
+  readonly maxLockResets: number = 15;
 
   // Visual Effects
   effectEvent: string | null = null;

--- a/src/webgpu/shaders/background.ts
+++ b/src/webgpu/shaders/background.ts
@@ -46,7 +46,7 @@ export const BackgroundShaders = () => {
           // Level 1: Calm blue
           // Level 10: Chaotic red
           // JUICE: Faster ramp up to "danger" colors (max at level 8)
-          let levelFactor = min(level * 0.125, 1.0);
+          let levelFactor = clamp((level - 1.0) / 9.0, 0.0, 1.0);
 
           // Base deep space color - shifts to red as level increases
           // NEON BRICKLAYER: More dramatic shift from Calm Blue to Chaotic Red/Purple

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -114,7 +114,7 @@ export const PostProcessShaders = () => {
 
             let baseAberration = vignetteAberration + levelAberration;
             // Add glitch aberration
-            let glitchAberration = glitchStrength * 0.05;
+            let glitchAberration = glitchStrength * 0.08;
             let totalAberration = baseAberration + shockwaveAberration + glitchAberration;
 
             // Chromatic Aberration with Glitch Offset

--- a/src/webgpu/shaders/premiumBlocks.ts
+++ b/src/webgpu/shaders/premiumBlocks.ts
@@ -442,9 +442,10 @@ export const PremiumBlockShaders = () => {
             
             // Rim lighting (enhanced for all materials)
             let rimPower = 1.0 - NdotV;
-            rimPower = rimPower * rimPower * rimPower * rimPower;
+            let rimPower2 = rimPower * rimPower;
+            let rimPower4 = rimPower2 * rimPower2;
             let rimColor = mix(vColor.rgb, vec3<f32>(1.0), metallic);
-            finalColor += rimColor * rimPower * 0.5;
+            finalColor += rimColor * rimPower4 * 0.4;
             
             // Emissive (for cyber/neon)
             let emissiveStrength = vColor.a > 0.8 ? 0.0 : 1.0; // Only for full blocks
@@ -486,6 +487,10 @@ export const PremiumBlockShaders = () => {
                 finalColor = applyParticleInteraction(matType, finalColor, N, L, V, particleIntensity, time);
             }
             
+            // Amplified emissive pulse for more visible pulsing effect
+            let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
+            finalColor += baseColor * emissivePulse * 0.8;
+
             // HDR tone mapping (simple Reinhard)
             finalColor = finalColor / (finalColor + vec3<f32>(1.0));
 

--- a/src/webgpu/shaders/underwaterBlocks.ts
+++ b/src/webgpu/shaders/underwaterBlocks.ts
@@ -400,11 +400,12 @@ export const UnderwaterBlockShaders = () => {
                 finalColor = mix(finalColor, finalColor * vec3f(0.9, 0.95, 1.1), 0.3);
             }
             
-            // Rim lighting
+            // Rim lighting - Fresnel Schlick approximation (rimPower^4) for brighter edge glow
             let rimPower = 1.0 - NdotV;
-            rimPower = rimPower * rimPower;
+            let rimPower2 = rimPower * rimPower;
+            let rimPower4 = rimPower2 * rimPower2;
             let rimColor = mix(vColor.rgb, vec3f(1.0), anyMetal * fUniforms.metallic);
-            finalColor += rimColor * rimPower * 0.1;
+            finalColor += rimColor * rimPower4 * 0.4;
             
             // Lock tension
             let lockPercent = fUniforms.lockPercent;
@@ -435,6 +436,10 @@ export const UnderwaterBlockShaders = () => {
                 return vec4f(ghostColor, 0.35 + scan * 0.2);
             }
             
+            // Amplified emissive pulse for more visible pulsing effect
+            let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
+            finalColor += baseColor * emissivePulse * 0.8;
+
             // Tone mapping
             finalColor = acesToneMapping(finalColor);
             

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -207,9 +207,9 @@ export function triggerImpactEffects(view: any, worldX: number, impactY: number,
   const uvX = 0.5 + (worldX - 10.0) / visibleWidth;
   const uvY = 0.5 - (impactY - camY) / visibleHeight;
 
-  const strength = 2.5 + Math.min(distance * 0.2, 1.0);
-  const width = 1.2 + Math.min(distance * 0.1, 0.6);
-  const aberration = 0.4 + Math.min(distance * 0.06, 0.8);
+  const strength = 3.5 + Math.min(distance * 0.3, 1.5);
+  const width = 1.5 + Math.min(distance * 0.2, 0.8);
+  const aberration = 0.6 + Math.min(distance * 0.1, 1.0);
   const speed = 5.0 + Math.min(distance * 0.4, 4.0);
 
   view.visualEffects.triggerShockwave([uvX, uvY], width, strength, aberration, speed);


### PR DESCRIPTION
Implemented the requested visual spectacles and game feel adjustments for "The Neon Bricklayer."

- The `pulse` and `fresnel` rim lighting components of `premiumBlocks.ts` and `underwaterBlocks.ts` have been augmented.
- The `background.ts` WGSL background shader correctly clamps level color scaling across exactly levels 1-10.
- `viewGameEvents.ts` and `postProcess.ts` push slightly stronger coefficients to `shockwaveParams` and `glitchAberration`.
- `game.ts` game loop logic was updated to lock earlier (`15` resets instead of `25`).

---
*PR created automatically by Jules for task [7506464609577343836](https://jules.google.com/task/7506464609577343836) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Gameplay**
  * Refined piece locking mechanics and hard drop behavior
  * Enhanced T-Spin state tracking and scoring integration
  * Improved reactive feedback for level advancement and game-over events

* **Visual Improvements**
  * Enhanced rim-lighting and emissive effects on premium and underwater blocks
  * Increased glitch aberration visual intensity in post-processing
  * Strengthened impact visual effects and feedback during gameplay interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->