### PR TITLE
perf: Cap WebGPU particle count at 5000

### DIFF
--- a/src/webgpu/particles.ts
+++ b/src/webgpu/particles.ts
@@ -15,7 +15,7 @@ export interface Particle {
 
 export class ParticleSystem {
     particles: Particle[] = [];
-    maxParticles: number = 10000; // Increased to 10000 for Neon Bricklayer intensity
+    maxParticles: number = 5000; // Capped to 5000 for Neon Bricklayer intensity
 
     // Ring Buffer strategy for emissions
     private emitIndex: number = 0;


### PR DESCRIPTION
This PR fixes performance issues with particles lagging the browser by reducing the `maxParticles` limit from 10000 to 5000 in `src/webgpu/particles.ts`.

It strictly implements the rule: "Do particles lag the browser? (Cap particle count if > 5000)". Tests and WASM builds have been verified locally.

---
*PR created automatically by Jules for task [5447190884914161659](https://jules.google.com/task/5447190884914161659) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted particle system limits to optimize performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/285)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->