### PR TITLE
🎨 Fix missing material textures for premium blocks

### DIFF
--- a/src/webgpu/viewMaterials.ts
+++ b/src/webgpu/viewMaterials.ts
@@ -72,7 +72,7 @@ export function updateMaterialUniforms(view: MaterialViewLike) {
   view._materialUniforms[6] = m.anisotropic;
   view._materialUniforms[7] = m.dispersion;
   view._materialUniforms[8] = view.particleInteractionUniforms.particleInfluence;
-  view._materialUniforms[9] = 0;
+  view._materialUniforms[9] = view.usePremiumMaterials ? 1.0 : 0.0;
 
   view.device.queue.writeBuffer(view.materialUniformBuffer, 0, view._materialUniforms.subarray(0, 4));
 }


### PR DESCRIPTION
🎨 Fix missing material textures for premium blocks

The `textureMix` uniform was incorrectly not being set on the CPU side, defaulting to 0.0 in the shader. This completely bypassed the texture logic, meaning blocks weren't receiving their gold/glass features.

This commit properly populates the `textureMix` value in the fragment uniform buffer based on whether premium materials are enabled (`usePremiumMaterials`), restoring the correct behavior where blocks render their premium textures correctly.

---
*PR created automatically by Jules for task [9946946645266248809](https://jules.google.com/task/9946946645266248809) started by @ford442*