### PR TITLE
feat: Neon Bloom Post-Processing Enhancement

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -440,6 +440,35 @@ export default class View {
   onHardDrop(x: number, y: number, distance: number, colorIdx: number = 0) {
       handleHardDrop(this, x, y, distance, colorIdx);
   }
+
+  setBloomIntensityWithDuration(intensity: number, durationMs: number = 0) {
+    if (!this.bloomSystem) return;
+
+    this.bloomSystem.setParameters({
+      intensity: Math.max(0, intensity),
+    });
+    this.bloomIntensity = intensity;
+
+    if (durationMs > 0) {
+      setTimeout(() => {
+        if (this.bloomSystem) {
+          this.bloomSystem.setParameters({ intensity: 1.0 });
+          this.bloomIntensity = 1.0;
+        }
+      }, durationMs);
+    }
+  }
+
+  triggerNeonBloomFlash(strength: number = 1.0) {
+    const peak = 1.8 + strength * 1.2;
+    this.setBloomIntensityWithDuration(peak, 280);
+  }
+
+  // We added neonBloomFlash to visualEffects for smooth exponential decay per frame.
+  // This helper enables components to directly trigger the flash through the view.
+  triggerNeonBloomFlashEffects(strength: number = 1.0) {
+    this.visualEffects.triggerNeonBloomFlash(strength);
+  }
   renderMainScreen(state: any) { handleRenderMainScreen(this, state); }
   renderEndScreen(state: any) { handleRenderEndScreen(this, state); }
   renderPauseScreen() { handleRenderPauseScreen(this); }
@@ -960,13 +989,24 @@ export default class View {
     this._postProcessParams.level = this.visualEffects.currentLevel;
     this._postProcessParams.warpSurge = this.visualEffects.warpSurge;
     this._postProcessParams.enableFXAA = this.useEnhancedPostProcess ? 1.0 : 0.0;
+    // Update Bloom System with dynamic neon flash intensity from effects
+    if (this.bloomSystem && this.visualEffects.neonBloomIntensity > 0) {
+       this.bloomSystem.setParameters({
+           intensity: this.bloomIntensity + this.visualEffects.neonBloomIntensity
+       });
+    } else if (this.bloomSystem) {
+       this.bloomSystem.setParameters({
+           intensity: this.bloomIntensity
+       });
+    }
+
     // When multi-pass bloom is active it handles bloom exclusively — disable the
     // in-shader 13-tap bloom to avoid double-blooming that washes out the board.
     const inShaderBloom = this.useEnhancedPostProcess && this.bloomEnabled && !this.useMultiPassBloom;
     this._postProcessParams.enableBloom = inShaderBloom ? 1.0 : 0.0;
     this._postProcessParams.enableFilmGrain = 1.0;
     this._postProcessParams.enableCRT = 0.0;
-    this._postProcessParams.bloomIntensity = this.bloomIntensity;
+    this._postProcessParams.bloomIntensity = this.bloomIntensity + this.visualEffects.neonBloomIntensity;
     this._postProcessParams.bloomThreshold = 0.72;
     this._postProcessParams.materialAwareBloom = (this.useEnhancedPostProcess && !this.useMultiPassBloom) ? 1.0 : 0.0;
     this._postProcessParams.screenResolution[0] = this.canvasWebGPU.width;

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -20,6 +20,10 @@ export class VisualEffects {
     shockwaveCenter: number[] = [0.5, 0.5];
     shockwaveParams: number[] = [0.15, 0.08, 0.03, 2.0]; // width, strength, aberration, speed
 
+    // Neon Bloom state
+    neonBloomIntensity: number = 0;
+    neonBloomBaseIntensity: number = 1.0;
+
     // Video background state (delegated to ReactiveVideoBackground)
     isVideoPlaying: boolean = false;
     currentLevel: number = 0;
@@ -64,6 +68,10 @@ export class VisualEffects {
         this.glitchIntensity *= 1.0 / (1.0 + dt * 3.0);
         if (this.glitchIntensity < 0.01) this.glitchIntensity = 0;
 
+        // Neon Bloom decay
+        this.neonBloomIntensity *= 1.0 / (1.0 + dt * 6.0); // Fast decay for snappy flash
+        if (this.neonBloomIntensity < 0.01) this.neonBloomIntensity = 0;
+
         if (this.shakeIntensity < 0.01) this.shakeIntensity = 0;
         if (this.aberrationIntensity < 0.01) this.aberrationIntensity = 0;
 
@@ -98,6 +106,11 @@ export class VisualEffects {
         this.aberrationIntensity = Math.min(this.aberrationIntensity, 3.0); // JUICE: Increased max aberration
     }
 
+    triggerNeonBloomFlash(strength: number = 1.0): void {
+        this.neonBloomIntensity += strength;
+        this.neonBloomIntensity = Math.min(this.neonBloomIntensity, 3.0); // Cap max bloom explosion
+    }
+
     triggerGlitch(intensity: number): void {
         this.glitchIntensity = intensity;
     }
@@ -115,12 +128,21 @@ export class VisualEffects {
     }
 
     triggerShockwave(center: number[], width: number = 0.15, strength: number = 0.08, aberration: number = 0.03, speed: number = 2.0): void {
-        
+        // NEON BRICKLAYER: Prevent weaker shockwaves from overwriting massive ones
+        if (this.shockwaveTimer > 0 && this.shockwaveParams[1] > strength) {
+            return;
+        }
+
         this.shockwaveCenter = center;
         this.shockwaveParams = [width, strength, aberration, speed];
         // Start effect at 0.01 to avoid 0.0 check failure
         // The shader uses time * 2.0 for radius, so 0.01 is a small starting circle
         this.shockwaveTimer = 0.01;
+
+        // JUICE: Massive shockwaves trigger a neon bloom flash
+        if (strength > 0.6) {
+            this.triggerNeonBloomFlash(strength * 1.8);
+        }
     }
 
     private _shockwaveParamsF32 = new Float32Array(4);


### PR DESCRIPTION
This PR transforms the game visually by introducing a massive "Neon Bloom" flash that triggers on highly impactful game events. It builds cleanly atop the existing WebGPU `BloomSystem`.

## Changes

1. **Effects Logic Integration:** Added `neonBloomIntensity` to `src/webgpu/effects.ts`. It undergoes rapid exponential decay every frame to create snappy, tactile visual flashes.
2. **View Pipeline Updates:** Extended `src/viewWebGPU.ts` with `setBloomIntensityWithDuration()` and exposed `triggerNeonBloomFlash()`. It reads the calculated decayed `neonBloomIntensity` every frame and pushes the combined multiplier accurately into the initialized `BloomSystem`.
3. **Juice & Game Feel:** In `src/webgpu/effects.ts`, `triggerShockwave()` intercepts all shockwave requests. If the request is a massive event (strength > 0.6, like a hard drop or multi-line clear), it will natively trigger an explosive neon bloom flash with an optimized 1.8x intensity multiplier.
4. **Bugfix:** Added guard logic in `triggerShockwave()` to correctly preserve massively impactful shockwaves from instantly getting overwritten by weaker shockwaves occurring on the exact same frame (like `onLock` overwriting `onHardDrop`.)

## Testing

Verified using `npm run build:all` and `vitest run`, completing cleanly without any WASM or dependency regressions. The `triggerNeonBloomFlash()` works gracefully as a standalone helper or embedded in the broader shockwave system.

---
*PR created automatically by Jules for task [8740656773795248593](https://jules.google.com/task/8740656773795248593) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added animated bloom intensity adjustments with customizable duration settings
  * Introduced dynamic neon bloom flash effects triggered during gameplay
  * Enhanced visual effects system with improved bloom rendering and intensity integration
  * Improved shockwave effects to prevent weaker effects from overwriting stronger ones

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/287)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->