### PR TITLE
Fix WGSL struct syntax: use commas instead of semicolons

### DIFF
--- a/src/webgpu/shaders/videoBackground.ts
+++ b/src/webgpu/shaders/videoBackground.ts
@@ -2,8 +2,8 @@ export function VideoBackgroundShaders() {
   return {
     vertex: `
       struct VertexOutput {
-        @builtin(position) position: vec4<f32>;
-        @location(0) uv: vec2<f32>;
+        @builtin(position) position: vec4<f32>,
+        @location(0) uv: vec2<f32>
       };
 
       @vertex
@@ -19,7 +19,7 @@ export function VideoBackgroundShaders() {
       @group(0) @binding(1) var videoTex: texture_external;
 
       struct FragmentInput {
-        @location(0) uv: vec2<f32>;
+        @location(0) uv: vec2<f32>
       };
 
       @fragment


### PR DESCRIPTION
## Summary

Fixed WGSL struct syntax errors in the video background shader. The shader compiler was rejecting struct declarations because members were separated by semicolons instead of commas.

## Changes

- **videoBackground.ts**: Changed struct member separators from semicolons (`;`) to commas (`,`) in both `VertexOutput` and `FragmentInput` structs

## Details

WGSL spec requires commas between struct members, not semicolons. The error message was:
```
error: expected '}' for struct declaration
        @builtin(position) position: vec4<f32>;
```

This has been fixed for both vertex and fragment shader structs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsYPAsVCUDCKEvfeFEjJLV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shader syntax to ensure proper video background rendering compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/291)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->