### PR TITLE
fix: restore gold/glass block visuals and fix upside-down video background

### DIFF
--- a/src/webgpu/blockTexture.ts
+++ b/src/webgpu/blockTexture.ts
@@ -90,8 +90,8 @@ export const DEFAULT_BLOCK_TEXTURE_CONFIG: BlockTextureConfig = {
   atlasTileRow: 1,
   atlasTileInset: 0.03,
   materialDetectionMode: 'color_signal',
-  metalThresholdLow: 0.8,
-  metalThresholdHigh: 1.2,
+  metalThresholdLow: 0.05,
+  metalThresholdHigh: 0.55,
   useProceduralFallback: true,
 };
 

--- a/src/webgpu/shaders/videoBackground.ts
+++ b/src/webgpu/shaders/videoBackground.ts
@@ -10,7 +10,8 @@ export function VideoBackgroundShaders() {
       fn main(@location(0) position: vec3<f32>) -> VertexOutput {
         var output: VertexOutput;
         output.position = vec4<f32>(position, 1.0);
-        output.uv = position.xy * 0.5 + vec2<f32>(0.5, 0.5);
+        // Flip Y: NDC has +1 at top, textures have 0 at top
+        output.uv = vec2<f32>(position.x * 0.5 + 0.5, 0.5 - position.y * 0.5);
         return output;
       }
     `,

--- a/src/webgpu/textureSampling.ts
+++ b/src/webgpu/textureSampling.ts
@@ -200,8 +200,9 @@ fn transformUVForSampling(uv: vec2<f32>) -> vec2<f32> {
 }
 
 fn extractMaterialMask(texColor: vec3<f32>) -> vec2<f32> {
-    let goldSignal = texColor.r + texColor.g - texColor.b * 0.5;
-    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.75}, ${config.metalThresholdHigh ?? 1.15}, goldSignal);
+    // Warmth (R-B): gold frame is warm (+0.6), cool glass center is cold (-0.1)
+    let warmth = texColor.r - texColor.b;
+    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.05}, ${config.metalThresholdHigh ?? 0.55}, warmth);
     return vec2<f32>(metalMask, 1.0 - metalMask);
 }
 `;


### PR DESCRIPTION
## Summary

- **Video background upside-down**: the WebGPU video pipeline was computing UV Y as `position.y * 0.5 + 0.5`, which maps NDC top (+1) to texture bottom (1.0), flipping the video. Fixed to `0.5 - position.y * 0.5`.
- **Blocks looked uniformly metallic**: the `extractMaterialMask` formula `r + g - b*0.5` (thresholds 0.8–1.2) scored the cool blue-tinted glass crystal center at ~1.16, classifying it as 90% metal and making all blocks appear gold/metallic with no glass translucency. Replaced with `warmth = r - b` which perfectly separates the warm gold frame (≈+0.65) from the cool glass interior (≈−0.10). Updated `DEFAULT_BLOCK_TEXTURE_CONFIG` thresholds to (0.05, 0.55) to match the new warmth signal range.

## Test plan
- [ ] Open the game and verify blocks show the gold frame + translucent glass center look (matching go.1ink.us)
- [ ] Confirm the video background plays right-side up
- [ ] Check that glass blocks have partial transparency (alpha ~0.75) vs gold frame fully opaque

https://claude.ai/code/session_01E1WcVU4fmrGNHsELEVnh6B

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1WcVU4fmrGNHsELEVnh6B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted material detection parameters for improved surface rendering accuracy
  * Corrected video background shader coordinate calculation to fix display orientation
  * Refined texture sampling algorithm for enhanced material detection precision

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/292)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->