### PR TITLE
Fix texture sampling and block config test failures

### DIFF
--- a/src/webgpu/blockTexture.ts
+++ b/src/webgpu/blockTexture.ts
@@ -89,7 +89,7 @@ export const DEFAULT_BLOCK_TEXTURE_CONFIG: BlockTextureConfig = {
   atlasTileColumn: 1,
   atlasTileRow: 1,
   atlasTileInset: 0.03,
-  materialDetectionMode: 'luminance',
+  materialDetectionMode: 'color_signal',
   metalThresholdLow: 0.35,
   metalThresholdHigh: 0.45,
   useProceduralFallback: true,

--- a/src/webgpu/textureSampling.ts
+++ b/src/webgpu/textureSampling.ts
@@ -165,6 +165,24 @@ fn getAtlasTransform() -> vec4<f32> {
 export function getSimpleTextureSamplingWGSL(): string {
   const config = getBlockTextureConfig();
   
+  let materialMaskLogic = `
+    let luma = dot(texColor.rgb, vec3<f32>(0.299, 0.587, 0.114));
+    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.45}, ${config.metalThresholdHigh ?? 0.55}, luma);
+  `;
+
+  if (config.materialDetectionMode === 'color_signal') {
+    materialMaskLogic = `
+    let goldSignal = texColor.r + texColor.g - texColor.b * 0.5;
+    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.35}, ${config.metalThresholdHigh ?? 0.45}, goldSignal);
+    `;
+  } else if (config.materialDetectionMode === 'luminance' && config.samplingMode === 'atlas') {
+      materialMaskLogic = `
+    // Luminance: bright silver/white frame maps to metal, dark marble center maps to glass
+    let luma = dot(texColor.rgb, vec3<f32>(0.299, 0.587, 0.114));
+    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.35}, ${config.metalThresholdHigh ?? 0.45}, luma);
+      `;
+  }
+
   // For simple shaders, we inline the constants directly
   if (config.samplingMode === 'single') {
     return `
@@ -173,9 +191,7 @@ fn transformUVForSampling(uv: vec2<f32>) -> vec2<f32> {
     return vec2<f32>(uv.x, 1.0 - uv.y);
 }
 
-fn extractMaterialMask(texColor: vec3<f32>) -> vec2<f32> {
-    let luma = dot(texColor.rgb, vec3<f32>(0.299, 0.587, 0.114));
-    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.45}, ${config.metalThresholdHigh ?? 0.55}, luma);
+fn extractMaterialMask(texColor: vec3<f32>) -> vec2<f32> {${materialMaskLogic}
     return vec2<f32>(metalMask, 1.0 - metalMask);
 }
 `;
@@ -199,10 +215,7 @@ fn transformUVForSampling(uv: vec2<f32>) -> vec2<f32> {
             (vec2<f32>(1.0) - atlasInset * 2.0) + atlasInset + atlasTile) / atlasTiles;
 }
 
-fn extractMaterialMask(texColor: vec3<f32>) -> vec2<f32> {
-    // Luminance: bright silver/white frame maps to metal, dark marble center maps to glass
-    let luma = dot(texColor.rgb, vec3<f32>(0.299, 0.587, 0.114));
-    let metalMask = smoothstep(${config.metalThresholdLow ?? 0.35}, ${config.metalThresholdHigh ?? 0.45}, luma);
+fn extractMaterialMask(texColor: vec3<f32>) -> vec2<f32> {${materialMaskLogic}
     return vec2<f32>(metalMask, 1.0 - metalMask);
 }
 `;


### PR DESCRIPTION
This commit addresses two failing tests in `tests/block-texture.test.ts` and `tests/texture-sampling.test.ts`.

It updates the default block texture config to use `'color_signal'` rather than `'luminance'` and fixes a bug where `getSimpleTextureSamplingWGSL` was hardcoding the luminance logic rather than checking the active `materialDetectionMode` configuration.

---
*PR created automatically by Jules for task [8060482218568588684](https://jules.google.com/task/8060482218568588684) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced block texture material detection by transitioning from luminance-based to color-signal-based detection methods. This improves visual accuracy and rendering quality when sampling textures, enabling more consistent and flexible material identification across different rendering modes and configurations for better overall visual fidelity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->