### PR TITLE
Apply material theme when switching themes

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -415,6 +415,10 @@ export default class View {
         this._f32_3.set(bgColors[2]);
         this.device.queue.writeBuffer(this.backgroundUniformBuffer, 48, this._f32_3);
     }
+
+    if (this.currentTheme.materialTheme) {
+        this.setMaterialTheme(this.currentTheme.materialTheme);
+    }
   }
 
   renderPiece(ctx: CanvasRenderingContext2D, piece: any, blockSize: number = 20) {


### PR DESCRIPTION
setTheme() updates colors but never invoked setMaterialTheme(), so gold, glass, and other PBR material presets defined in themes were ignored. Selecting 'gold' or 'glass' from the UI now correctly applies their metallic/roughness/transmission/IOR properties to the renderer.

https://claude.ai/code/session_01MsYPAsVCUDCKEvfeFEjJLV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme system now applies material theme configurations automatically when defined for a selected theme.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->