### PR TITLE
Fix PBR block rendering: wire up pbrBlocks.ts and align uniform buffer layout

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -567,7 +567,7 @@ export default class View {
         }
     }
 
-    const shader = Shaders();
+    const shader = PBRBlockShaders();
     const cubeData = CubeData();
     this.numberOfVertices = cubeData.positions.length / 3;
     this.vertexBuffer = this.CreateGPUBuffer(this.device, cubeData.positions);
@@ -753,10 +753,7 @@ export default class View {
     this.device.queue.writeBuffer(this.fragmentUniformBuffer, 0, lightPosition);
     this._f32_3.set(eyePosition);
     this.device.queue.writeBuffer(this.fragmentUniformBuffer, 16, this._f32_3);
-    this._f32_4.set(this.currentTheme[5] || [1.0, 1.0, 1.0, 1.0]);
-    this.device.queue.writeBuffer(this.fragmentUniformBuffer, 32, this._f32_4);
-    this._f32_1[0] = this.useGlitch ? 1.0 : 0.0;
-    this.device.queue.writeBuffer(this.fragmentUniformBuffer, 52, this._f32_1);
+    // Bytes 32-47 are time/useGlitch/lockPercent/level — zeroed here, updated each frame
 
     // Create material uniform buffer for PBR (binding 4) - MUST be before renderPlayfield_Border_WebGPU
     this.materialUniformBuffer = this.device.createBuffer({
@@ -784,7 +781,6 @@ export default class View {
                 { binding: 1, resource: { buffer: this.fragmentUniformBuffer, offset: 0, size: 144 } },
                 { binding: 2, resource: this.blockTexture.createView({ format: 'rgba8unorm', dimension: '2d', baseMipLevel: 0, mipLevelCount: this.blockTexture.mipLevelCount }) },
                 { binding: 3, resource: this.blockSampler },
-                { binding: 4, resource: { buffer: this.materialUniformBuffer, offset: 0, size: 16 } }
             ],
         });
         this.uniformBindGroup_CACHE.push(bindGroup);
@@ -841,7 +837,7 @@ export default class View {
     if (!this.device) return;
     const result = renderPlayfieldBorder(
       this.device, this.pipeline, this.fragmentUniformBuffer,
-      this.blockTexture, this.blockSampler, this.materialUniformBuffer,
+      this.blockTexture, this.blockSampler,
       this.vpMatrix as Float32Array, this.currentTheme,
       this._f32_3, this._f32_4, this.MODELMATRIX, this.NORMALMATRIX
     );

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -72,7 +72,39 @@ fn subsurfaceScattering(NdotL: f32, subsurface: f32, color: vec3f) -> vec3f {
 `;
 
 export const PBRBlockShaders = () => {
-    const vertex = `...`; // (unchanged — your original vertex shader)
+    const vertex = `
+        struct VertexUniforms {
+            viewProjectionMatrix : mat4x4<f32>,
+            modelMatrix          : mat4x4<f32>,
+            normalMatrix         : mat4x4<f32>,
+            colorVertex          : vec4<f32>
+        };
+        @binding(0) @group(0) var<uniform> vUniforms : VertexUniforms;
+
+        struct VertexOutput {
+            @builtin(position) Position : vec4f,
+            @location(0) vWorldPos      : vec4f,
+            @location(1) vNormal        : vec3f,
+            @location(2) vColor         : vec4f,
+            @location(3) vUV            : vec2f
+        };
+
+        @vertex
+        fn main(
+            @location(0) position : vec4<f32>,
+            @location(1) normal   : vec4<f32>,
+            @location(2) uv       : vec2<f32>
+        ) -> VertexOutput {
+            var out: VertexOutput;
+            let worldPos         = vUniforms.modelMatrix * position;
+            out.vWorldPos        = worldPos;
+            out.vNormal          = (vUniforms.normalMatrix * normal).xyz;
+            out.Position         = vUniforms.viewProjectionMatrix * worldPos;
+            out.vColor           = vUniforms.colorVertex;
+            out.vUV              = uv;
+            return out;
+        }
+    `;
 
     // Get configurable texture sampling code
     const textureSamplingCode = getSimpleTextureSamplingWGSL();
@@ -123,12 +155,11 @@ export const PBRBlockShaders = () => {
         fn main(@location(0) vWorldPos : vec4f,
                 @location(1) vNormal : vec3f,
                 @location(2) vColor : vec4f,
-                @location(3) vUV : vec2f,
-                @location(4) vViewDir : vec3f) -> @location(0) vec4f {
+                @location(3) vUV : vec2f) -> @location(0) vec4f {
 
             let time = fUniforms.time;
             let N = normalize(vNormal);
-            let V = vViewDir;
+            let V = normalize(fUniforms.eyePosition.xyz - vWorldPos.xyz);
             let L = normalize(fUniforms.lightPosition.xyz - vWorldPos.xyz);
             let H = normalize(L + V);
             let NdotL = max(dot(N, L), 0.0);

--- a/src/webgpu/viewMaterials.ts
+++ b/src/webgpu/viewMaterials.ts
@@ -56,13 +56,31 @@ export function setMaterialTheme(view: MaterialViewLike, themeName: string, piec
   renderLogger.info(`Switched to ${themeName} with material ${materialThemeName}`);
 }
 
+// Maps material names to pbrBlocks.ts materialType indices
+// 0=Classic, 1=Gold, 2=Chrome, 3=Glass, 4=Cyber, 5=Gem
+function getMaterialTypeIndex(name: string): number {
+  switch (name) {
+    case 'Gold':    return 1;
+    case 'Chrome':  return 2;
+    case 'Glass':   return 3;
+    case 'Cyber':   return 4;
+    case 'Ruby': case 'Sapphire': case 'Emerald': return 5;
+    default:        return 0;
+  }
+}
+
 /**
  * Write material uniform data to the fragment uniform buffer.
+ * Offsets match pbrBlocks.ts FragmentUniforms: metallic starts at byte 48,
+ * materialType (u32) at byte 80, particleIntensity/enablePBR/textureMix at 84-92.
  */
 export function updateMaterialUniforms(view: MaterialViewLike) {
   if (!view.device || !view.currentMaterial) return;
 
   const m = view.currentMaterial;
+
+  // Floats: metallic(48) roughness(52) transmission(56) ior(60)
+  //         subsurface(64) clearcoat(68) anisotropic(72) dispersion(76)
   view._materialUniforms[0] = m.metallic;
   view._materialUniforms[1] = m.roughness;
   view._materialUniforms[2] = m.transmission;
@@ -71,10 +89,17 @@ export function updateMaterialUniforms(view: MaterialViewLike) {
   view._materialUniforms[5] = m.clearcoat;
   view._materialUniforms[6] = m.anisotropic;
   view._materialUniforms[7] = m.dispersion;
-  view._materialUniforms[8] = view.particleInteractionUniforms.particleInfluence;
-  view._materialUniforms[9] = 0.0;
+  view.device.queue.writeBuffer(view.fragmentUniformBuffer, 48, view._materialUniforms.subarray(0, 8));
 
-  view.device.queue.writeBuffer(view.materialUniformBuffer, 0, view._materialUniforms.subarray(0, 4));
+  // materialType as u32 at byte 80 — must use Uint32Array to write correct bit pattern
+  const u32Scratch = new Uint32Array([getMaterialTypeIndex(m.name)]);
+  view.device.queue.writeBuffer(view.fragmentUniformBuffer, 80, u32Scratch);
+
+  // particleIntensity(84) enablePBR(88) textureMix(92)
+  view._materialUniforms[0] = view.particleInteractionUniforms.particleInfluence;
+  view._materialUniforms[1] = view.usePremiumMaterials ? 1.0 : 0.0;
+  view._materialUniforms[2] = m.name === 'Image Sampled' ? 1.0 : 0.5;
+  view.device.queue.writeBuffer(view.fragmentUniformBuffer, 84, view._materialUniforms.subarray(0, 3));
 }
 
 /**

--- a/src/webgpu/viewPlayfield.ts
+++ b/src/webgpu/viewPlayfield.ts
@@ -123,7 +123,6 @@ export function renderPlayfieldBorder(
   fragmentUniformBuffer: GPUBuffer,
   blockTexture: GPUTexture,
   blockSampler: GPUSampler,
-  materialUniformBuffer: GPUBuffer,
   vpMatrix: Float32Array | Matrix.mat4,
   currentTheme: any,
   _f32_3: Float32Array,
@@ -155,7 +154,6 @@ export function renderPlayfieldBorder(
           { binding: 1, resource: { buffer: fragmentUniformBuffer, offset: 0, size: 144 } },
           { binding: 2, resource: blockTexture.createView({ format: 'rgba8unorm', dimension: '2d', baseMipLevel: 0, mipLevelCount: blockTexture.mipLevelCount }) },
           { binding: 3, resource: blockSampler },
-          { binding: 4, resource: { buffer: materialUniformBuffer, offset: 0, size: 16 } }
         ],
       });
 

--- a/src/webgpu/viewUniforms.ts
+++ b/src/webgpu/viewUniforms.ts
@@ -104,15 +104,16 @@ export function updateFrameUniforms(view: any, dt: number, time: number): FrameU
   view._f32_1[0] = ghostUVW;
   device.queue.writeBuffer(view.backgroundUniformBuffer, 76, view._f32_1);
 
-  // Block (fragment) uniforms
+  // Block (fragment) uniforms — offsets match pbrBlocks.ts FragmentUniforms:
+  // lightPosition(0), eyePosition(16), time(32), useGlitch(36), lockPercent(40), level(44)
   view._f32_1[0] = time;
-  device.queue.writeBuffer(view.fragmentUniformBuffer, 48, view._f32_1);
+  device.queue.writeBuffer(view.fragmentUniformBuffer, 32, view._f32_1);
   view._f32_1[0] = view.useGlitch ? 1.0 : 0.0;
-  device.queue.writeBuffer(view.fragmentUniformBuffer, 52, view._f32_1);
+  device.queue.writeBuffer(view.fragmentUniformBuffer, 36, view._f32_1);
   view._f32_1[0] = lockPercent;
-  device.queue.writeBuffer(view.fragmentUniformBuffer, 56, view._f32_1);
+  device.queue.writeBuffer(view.fragmentUniformBuffer, 40, view._f32_1);
   view._f32_1[0] = view.visualEffects.currentLevel;
-  device.queue.writeBuffer(view.fragmentUniformBuffer, 60, view._f32_1);
+  device.queue.writeBuffer(view.fragmentUniformBuffer, 44, view._f32_1);
 
   // Underwater / bioluminescent uniforms
   const isUnderwaterLevel = view.reactiveVideoBackground?.isSeaCreatureLevel ?? false;


### PR DESCRIPTION
## Summary

- **Root cause**: `PBRBlockShaders` was imported but the main pipeline still used `Shaders()` (main.ts), which has a different `FragmentUniforms` layout — an extra `color: vec4f` field at offset 32 shifts `time` to offset 48. Meanwhile `viewUniforms.ts` wrote `time`/`useGlitch`/`lockPercent`/`level` at 48/52/56/60, which are the **material property slots** in pbrBlocks.ts's struct. Metal and glass materials received garbage values (time-as-metallic, useGlitch-as-roughness, etc.).
- **Secondary cause**: `viewMaterials.ts` wrote material properties to a separate `materialUniformBuffer` (binding 4), which pbrBlocks.ts does not declare — those values were never read by the shader.

## Changes

- **`pbrBlocks.ts`**: Add proper WGSL vertex shader matching the existing float32x3 vertex buffer layout; compute view direction `V` from `eyePosition` in the fragment stage, removing the need for `@location(4) vViewDir` interpolant.
- **`viewWebGPU.ts`**: Switch main pipeline to `PBRBlockShaders()`; remove stale theme-colour write at offset 32 (was the old `color` field, now `time`); drop binding 4 (`materialUniformBuffer`) from all block bind groups.
- **`viewUniforms.ts`**: Fix per-frame offsets to match pbrBlocks.ts struct — `time→32`, `useGlitch→36`, `lockPercent→40`, `level→44`.
- **`viewMaterials.ts`**: Write all 12 PBR material properties into `fragmentUniformBuffer` at offset 48; write `materialType` as `Uint32Array` (correct bit pattern for u32 comparison in WGSL); derive `enablePBR` from `usePremiumMaterials`.
- **`viewPlayfield.ts`**: Remove `materialUniformBuffer` parameter from `renderPlayfieldBorder` — binding 4 is no longer in the pipeline layout.

## Test plan

- [ ] Launch game in Chrome with WebGPU enabled
- [ ] Verify blocks render with correct colours (no grey static)
- [ ] Switch to gold/chrome theme — verify metallic PBR lighting and reflections
- [ ] Switch to glass theme — verify refraction and Fresnel transparency
- [ ] Verify ghost piece hologram still renders
- [ ] Verify lock-tension pulse effect still activates near lock
- [ ] Verify glitch mode still works (`G` key)
- [ ] Run `npm run test` — all unit tests pass

https://claude.ai/code/session_012ePcanaHdaGcQfGUVkDKXt

---
_Generated by [Claude Code](https://claude.ai/code/session_012ePcanaHdaGcQfGUVkDKXt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Upgraded block rendering to use Physically Based Rendering (PBR) shaders for improved material realism and visual quality.
  * Refactored shader uniforms and buffer layouts for more efficient rendering pipeline organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->