### PR TITLE
Enhance visual juice for Neon Bricklayer persona

### DIFF
--- a/src/webgpu/shaders/main.ts
+++ b/src/webgpu/shaders/main.ts
@@ -251,6 +251,10 @@ export const Shaders = () => {
                      }
                 }
 
+                // Amplified emissive pulse for more visible pulsing effect
+                let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
+                finalColor += finalColor * emissivePulse * 0.25;
+
                 // Subtle Surface Noise (Texture)
                 let noise = fract(sin(dot(vUV, vec2<f32>(12.9898, 78.233))) * 43758.5453);
                 finalColor += vec3<f32>(noise) * 0.015;

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -283,6 +283,8 @@ export function onHardDrop(view: any, x: number, y: number, distance: number, co
   const impactY = y * -2.2;
   const burstColor = [...themeColors, 1.0];
   view.visualEffects.triggerFlash(0.1);
+  view.visualEffects.triggerAberration(1.5); // JUICE: Heavy chromatic aberration on hard drop
+  view.visualEffects.triggerNeonBloomFlash(2.0); // JUICE: Explode with neon bloom on hard drop
 
   // JUICE: Multiplied particle speeds and counts by 2.0x for heavier impact
   for (let i = 0; i < 450; i++) {


### PR DESCRIPTION
This commit adds missing visual "juice" to the WebGPU renderer for the Neon Bricklayer persona. It adds an emissive, time-based pulse to the default block shader, making the board feel more alive, and heavily amplifies the Hard Drop impact by triggering severe chromatic aberration and a neon bloom flash, enhancing the overall game feel.

---
*PR created automatically by Jules for task [2995029051324906250](https://jules.google.com/task/2995029051324906250) started by @ford442*