### PR TITLE
Refactor Neon Bloom decay for snappier visual impact

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -10,3 +10,4 @@
 - "Increased the hard drop particle speed multiplier from 1.5x to 2.0x. The particles now explode outward with much more explosive force, adding an incredibly satisfying sense of heavy impact and 'crunch' to fast locks!"
 - "Massively boosted the Chromatic Aberration during shockwaves. Pushing the Red and Blue channels apart vertically and horizontally makes Hard Drops feel like they are tearing the screen apart!"
 - "Amplified the camera shake scaling and shockwave ripple speed on Hard Drops to make high-distance drops feel earth-shattering."
+- "Changed Neon Bloom decay to use true exponential decay (\`Math.exp(-dt * 10.0)\`) instead of algebraic decay. This makes the flashes hit instantly and dissipate smoothly, drastically improving the game feel."

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -69,7 +69,7 @@ export class VisualEffects {
         if (this.glitchIntensity < 0.01) this.glitchIntensity = 0;
 
         // Neon Bloom decay
-        this.neonBloomIntensity *= 1.0 / (1.0 + dt * 6.0); // Fast decay for snappy flash
+        this.neonBloomIntensity *= Math.exp(-dt * 10.0); // NEON BRICKLAYER: True exponential decay for snappy flash
         if (this.neonBloomIntensity < 0.01) this.neonBloomIntensity = 0;
 
         if (this.shakeIntensity < 0.01) this.shakeIntensity = 0;


### PR DESCRIPTION
Adopted the "Neon Bricklayer" persona to enhance the game's visual presentation ("juice").

Identified an opportunity in the post-processing effects where the Neon Bloom flash used an algebraic decay (`1.0 / (1.0 + dt * 6.0)`). Changed this to a true exponential decay (`Math.exp(-dt * 10.0)`) which creates a much snappier feel – the flash hits fast and smooths out cleanly, maximizing the impact of heavy events like Hard Drops. Added an entry to the `neon_bricklayers_journal.md` detailing the visual improvement, maintaining the persona's style. Verified all tests passed successfully with no regressions.

---
*PR created automatically by Jules for task [3643994806873817552](https://jules.google.com/task/3643994806873817552) started by @ford442*