### PR TITLE
feat: add neon bloom flash on T-Spin locks

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -11,3 +11,4 @@
 - "Massively boosted the Chromatic Aberration during shockwaves. Pushing the Red and Blue channels apart vertically and horizontally makes Hard Drops feel like they are tearing the screen apart!"
 - "Amplified the camera shake scaling and shockwave ripple speed on Hard Drops to make high-distance drops feel earth-shattering."
 - "Changed Neon Bloom decay to use true exponential decay (\`Math.exp(-dt * 10.0)\`) instead of algebraic decay. This makes the flashes hit instantly and dissipate smoothly, drastically improving the game feel."
+- "Adding Neon Bloom flash on T-Spin locks significantly enhances the rewarding feel of setting them up."

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -195,6 +195,7 @@ export function onLock(view: any, isTSpin: boolean = false): void {
   
   if (isTSpin && view.state?.activePiece) {
     // Extra T-Spin lock effects
+    view.visualEffects.triggerNeonBloomFlash(2.0); // JUICE: Boom!
     const { x, y } = view.state.activePiece;
     const worldX = (x + 1) * 2.2;
     const worldY = (y + 1) * -2.2;


### PR DESCRIPTION
This commit adds a `triggerNeonBloomFlash(2.0)` call in `src/webgpu/viewGameEvents.ts` when a T-Spin locks. This enhances the visual reward and "juice" for setting up T-Spins, aligning with the project's visual philosophy. It was verified manually and logged in the journal. Tests pass.

---
*PR created automatically by Jules for task [15979504125601614428](https://jules.google.com/task/15979504125601614428) started by @ford442*