### PR TITLE
feat(effects): Add 2.0x Neon Bloom flash on T-Spin locks

### DIFF
--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -208,6 +208,7 @@ export function onLock(view: any, isTSpin: boolean = false): void {
     // Flash effect
     view.visualEffects.triggerFlash(0.4);
     view.visualEffects.triggerAberration(0.3);
+    view.visualEffects.triggerNeonBloomFlash(2.0); // JUICE: Explode with neon bloom on T-Spin lock
   }
 }
 


### PR DESCRIPTION
This PR adds a 2.0x Neon Bloom flash visual effect whenever a T-Spin is locked, keeping the game-feel "juicy" and providing better visual feedback for this high-value action. It's tuned slightly lower than the hard drop bloom (3.0x) to give hard drops more impact while still making T-Spins feel rewarding.

---
*PR created automatically by Jules for task [548921426294091782](https://jules.google.com/task/548921426294091782) started by @ford442*