### PR TITLE
Fix screen shake exponential decay

### DIFF
--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -57,7 +57,7 @@ export class VisualEffects {
 
         // Exponential decay for smooth game feel (fast algebraic approximation for aberration, true exponential for shake)
         const aberrationDecay = 1.0 / (1.0 + dt * 3.0);
-        this.shakeIntensity *= 1.0 / (1.0 + dt * 15.0);
+        this.shakeIntensity *= Math.exp(-dt * 15.0);
         this.aberrationIntensity *= aberrationDecay;
 
         // Warp surge decay


### PR DESCRIPTION
Implemented true exponential decay for `shakeIntensity` as requested in the "Neon Bricklayer's Journal" log, to provide a snappier visual effect. Evaluated and preserved algebraic approximation for other visual effects (like `aberrationIntensity`) per the documentation. Validated with `npm run build:all` and `npm test` checks.

---
*PR created automatically by Jules for task [17636290182176275366](https://jules.google.com/task/17636290182176275366) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual shake effect fading behavior for smoother animation transitions during gameplay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Tetris_WebGPU/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->