### PR TITLE
feat: add supernova neon bloom and warp surge to line clears

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -12,3 +12,5 @@
 - "Amplified the camera shake scaling and shockwave ripple speed on Hard Drops to make high-distance drops feel earth-shattering."
 - "Changed Neon Bloom decay to use true exponential decay (\`Math.exp(-dt * 10.0)\`) instead of algebraic decay. This makes the flashes hit instantly and dissipate smoothly, drastically improving the game feel."
 - "Adding Neon Bloom flash on T-Spin locks significantly enhances the rewarding feel of setting them up."
+- "Added 'Supernova' Line Clears: triggering a massive Neon Bloom Flash that scales with the number of lines cleared. Tetrises and T-Spins now visually explode like a localized supernova!"
+- "Added 'Warp Surge' on big plays: tetrises and T-Spins now significantly distort the hyperspace tunnel background, making the big clears feel even more chaotic and impactful."

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -63,6 +63,18 @@ export function onLineClear(view: any, lines: number[], tSpin: boolean = false, 
     view.visualEffects.triggerAberration(0.3 + lines.length * 0.1);
   }
 
+  // JUICE: Supernova Line Clears
+  // Trigger a massive Neon Bloom Flash that scales with the number of lines cleared.
+  // Tetrises (4 lines) and T-Spins feel like a localized supernova.
+  const bloomIntensity = 1.0 + lines.length * 0.5;
+  view.visualEffects.triggerNeonBloomFlash(bloomIntensity);
+
+  // JUICE: Warp Surge on Big Plays
+  // If it's a Tetris or T-Spin, heavily distort the background hyperspace tunnel.
+  if (lines.length >= 4 || tSpin) {
+    view.visualEffects.triggerWarpSurge(2.0 + lines.length * 0.5);
+  }
+
   lines.forEach((y: number) => {
     const worldY = y * -2.2;
 


### PR DESCRIPTION
Implements "Supernova" Line Clears and "Warp Surge" on big plays, enhancing the visual feedback and impact according to the "JUICE" philosophy. The Neon Bloom flash now scales with lines cleared, making large clears feel explosive, while the background hyperspace tunnel warps dramatically on Tetrises and T-Spins.

---
*PR created automatically by Jules for task [7021832887701061314](https://jules.google.com/task/7021832887701061314) started by @ford442*