### PR TITLE
Add dynamic emissive pulse and rim lighting to block shaders

### DIFF
--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -24,6 +24,10 @@ export class VisualEffects {
     neonBloomIntensity: number = 0;
     neonBloomBaseIntensity: number = 1.0;
 
+    // Block Emissive state
+    movementFlashTimer: number = 0;
+    lineClearFlashTimer: number = 0;
+
     // Video background state (delegated to ReactiveVideoBackground)
     isVideoPlaying: boolean = false;
     currentLevel: number = 0;
@@ -72,6 +76,13 @@ export class VisualEffects {
         this.neonBloomIntensity *= 1.0 / (1.0 + dt * 10.0); // NEON BRICKLAYER: Fast algebraic approximation for snappy flash
         if (this.neonBloomIntensity < 0.01) this.neonBloomIntensity = 0;
 
+        // Block Emissive decay
+        this.movementFlashTimer *= 1.0 / (1.0 + dt * 8.0);
+        if (this.movementFlashTimer < 0.01) this.movementFlashTimer = 0;
+
+        this.lineClearFlashTimer *= 1.0 / (1.0 + dt * 4.0);
+        if (this.lineClearFlashTimer < 0.01) this.lineClearFlashTimer = 0;
+
         if (this.shakeIntensity < 0.01) this.shakeIntensity = 0;
         if (this.aberrationIntensity < 0.01) this.aberrationIntensity = 0;
 
@@ -89,6 +100,14 @@ export class VisualEffects {
 
     triggerRotate(duration: number = 0.2): void {
         this.rotationFlashTimer = duration;
+    }
+
+    triggerMovementFlash(duration: number = 1.0): void {
+        this.movementFlashTimer = duration;
+    }
+
+    triggerLineClearFlash(duration: number = 1.0): void {
+        this.lineClearFlashTimer = duration;
     }
 
     triggerLock(duration: number = 0.3): void {

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -132,7 +132,10 @@ export const PBRBlockShaders = () => {
             particleIntensity : f32,    // 84
             enablePBR     : f32,        // 88
             textureMix    : f32,        // 92
-            reserved      : vec4f,      // 96-111
+            movementFlash : f32,        // 96
+            lineClearFlash: f32,        // 100
+            pad1          : f32,        // 104
+            pad2          : f32,        // 108
             reserved2     : vec4f,      // 112-127
         };
         @binding(1) @group(0) var<uniform> fUniforms : FragmentUniforms;
@@ -269,7 +272,8 @@ export const PBRBlockShaders = () => {
             let rimPower2 = rimPower * rimPower;
             let rimPower4 = rimPower2 * rimPower2;
             let rimColor = mix(vColor.rgb, vec3f(1.0), metalMask * fUniforms.metallic);
-            finalColor += rimColor * rimPower4 * 5.0; // JUICE: Enhanced Fresnel Rim Lighting
+            let dynamicRim = 5.0 + (fUniforms.movementFlash * 3.0) + (fUniforms.lineClearFlash * 10.0);
+            finalColor += rimColor * rimPower4 * dynamicRim; // JUICE: Enhanced Fresnel Rim Lighting + Dynamic Flash
 
             // Lock tension effect
             let lockPercent = fUniforms.lockPercent;
@@ -293,8 +297,9 @@ export const PBRBlockShaders = () => {
             }
 
             // Amplified emissive pulse for more visible pulsing effect
-            let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
-            finalColor += baseColor * emissivePulse * 1.2;
+            let idlePulse = sin(time * 3.0) * 0.5 + 0.5;
+            let emissivePulse = idlePulse * 1.2 + fUniforms.movementFlash * 2.5 + fUniforms.lineClearFlash * 5.0;
+            finalColor += baseColor * emissivePulse;
 
             finalColor = acesToneMapping(finalColor);
             let materialAlpha = mix(0.85, 0.98, metalMask);

--- a/src/webgpu/shaders/premiumBlocks.ts
+++ b/src/webgpu/shaders/premiumBlocks.ts
@@ -299,8 +299,8 @@ export const PremiumBlockShaders = () => {
             // NEW: Particle interaction
             particleMaterialType : u32,  // 0=none, 1=glass, 2=gold, 3=chrome, 4=cyber, 5=gem
             particleIntensity : f32,
-            pad1 : f32,
-            pad2 : f32,
+            movementFlash : f32,
+            lineClearFlash : f32,
         };
         @binding(1) @group(0) var<uniform> fUniforms : FragmentUniforms;
         @binding(2) @group(0) var blockTexture : texture_2d<f32>;
@@ -445,7 +445,8 @@ export const PremiumBlockShaders = () => {
             let rimPower2 = rimPower * rimPower;
             let rimPower4 = rimPower2 * rimPower2;
             let rimColor = mix(vColor.rgb, vec3<f32>(1.0), metallic);
-            finalColor += rimColor * rimPower4 * 5.0; // JUICE: Enhanced Fresnel Rim Lighting
+            let dynamicRim = 5.0 + (fUniforms.movementFlash * 3.0) + (fUniforms.lineClearFlash * 10.0);
+            finalColor += rimColor * rimPower4 * dynamicRim; // JUICE: Enhanced Fresnel Rim Lighting + Dynamic Flash
             
             // Emissive (for cyber/neon)
             let emissiveStrength = vColor.a > 0.8 ? 0.0 : 1.0; // Only for full blocks
@@ -488,8 +489,9 @@ export const PremiumBlockShaders = () => {
             }
             
             // Amplified emissive pulse for more visible pulsing effect
-            let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
-            finalColor += baseColor * emissivePulse * 0.8;
+            let idlePulse = sin(time * 3.0) * 0.5 + 0.5;
+            let emissivePulse = idlePulse * 0.8 + fUniforms.movementFlash * 2.5 + fUniforms.lineClearFlash * 5.0;
+            finalColor += baseColor * emissivePulse;
 
             // HDR tone mapping (simple Reinhard)
             finalColor = finalColor / (finalColor + vec3<f32>(1.0));

--- a/src/webgpu/shaders/underwaterBlocks.ts
+++ b/src/webgpu/shaders/underwaterBlocks.ts
@@ -199,7 +199,10 @@ export const UnderwaterBlockShaders = () => {
             padding : f32,                   // 124
             
             // Reserved (offset 128)
-            reserved : vec4f,        // 128-143
+            movementFlash : f32,     // 128
+            lineClearFlash: f32,     // 132
+            pad1          : f32,     // 136
+            pad2          : f32,     // 140
         };
         
         @binding(1) @group(0) var<uniform> fUniforms : FragmentUniforms;
@@ -405,7 +408,8 @@ export const UnderwaterBlockShaders = () => {
             let rimPower2 = rimPower * rimPower;
             let rimPower4 = rimPower2 * rimPower2;
             let rimColor = mix(vColor.rgb, vec3f(1.0), anyMetal * fUniforms.metallic);
-            finalColor += rimColor * rimPower4 * 5.0; // JUICE: Enhanced Fresnel Rim Lighting
+            let dynamicRim = 5.0 + (fUniforms.movementFlash * 3.0) + (fUniforms.lineClearFlash * 10.0);
+            finalColor += rimColor * rimPower4 * dynamicRim; // JUICE: Enhanced Fresnel Rim Lighting + Dynamic Flash
             
             // Lock tension
             let lockPercent = fUniforms.lockPercent;
@@ -437,8 +441,9 @@ export const UnderwaterBlockShaders = () => {
             }
             
             // Amplified emissive pulse for more visible pulsing effect
-            let emissivePulse = sin(time * 3.0) * 0.5 + 0.5;
-            finalColor += baseColor * emissivePulse * 0.8;
+            let idlePulse = sin(time * 3.0) * 0.5 + 0.5;
+            let emissivePulse = idlePulse * 0.8 + fUniforms.movementFlash * 2.5 + fUniforms.lineClearFlash * 5.0;
+            finalColor += baseColor * emissivePulse;
 
             // Tone mapping
             finalColor = acesToneMapping(finalColor);

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -26,6 +26,14 @@ export function showFloatingText(view: any, text: string, subText: string = ""):
 
 export function onLineClear(view: any, lines: number[], tSpin: boolean = false, combo: number = 0, backToBack: boolean = false, isAllClear: boolean = false): void {
 
+  const base = 0.45;
+  const lineBonus = Math.min(lines.length * 0.12, 0.35);
+  const specialBonus = (tSpin || backToBack) ? 0.15 : 0;
+  const comboBonus = Math.min(combo * 0.03, 0.12);
+
+  const strength = Math.min(base + lineBonus + specialBonus + comboBonus, 0.95);
+  view.visualEffects.triggerLineClearFlash(strength);
+
   const camY = -20.0;
   const camZ = 75.0;
   const fov = (35 * Math.PI) / 180;
@@ -247,6 +255,7 @@ export function onHold(view: any): void {
 export function onRotate(view: any): void {
   view.visualEffects.triggerRotate(0.2);
   view.visualEffects.triggerAberration(0.15); // Add tactile visual bump
+  view.visualEffects.triggerMovementFlash(0.15);
 
   if (view.state && view.state.activePiece) {
     const { x, y } = view.state.activePiece;
@@ -516,6 +525,7 @@ export function renderPauseScreen(view: any): void {
 }
 
 export function onMove(view: any, x: number, y: number): void {
+  view.visualEffects.triggerMovementFlash(0.2);
   const worldX = (x + 1.5) * 2.2;
   const worldY = (y + 1.5) * -2.2;
   // JUICE: Denser, brighter trail for better feedback

--- a/src/webgpu/viewUniforms.ts
+++ b/src/webgpu/viewUniforms.ts
@@ -128,12 +128,27 @@ export function updateFrameUniforms(view: any, dt: number, time: number): FrameU
     }
     view.chaosMode.setUnderwaterMode(true);
     view.jellyfishSystem.update(dt, time);
+
+    // Write specifically for underwater layout offsets
+    view._f32_1[0] = view.visualEffects.movementFlashTimer;
+    device.queue.writeBuffer(view.fragmentUniformBuffer, 128, view._f32_1);
+    view._f32_1[0] = view.visualEffects.lineClearFlashTimer;
+    device.queue.writeBuffer(view.fragmentUniformBuffer, 132, view._f32_1);
   } else {
     view._f32_1[0] = 0.0;
     for (let offset = 96; offset <= 120; offset += 4) {
-      device.queue.writeBuffer(view.fragmentUniformBuffer, offset, view._f32_1);
+      // Skip 96 and 100 which are now used for movement/lineClear flash on non-underwater
+      if (offset !== 96 && offset !== 100) {
+        device.queue.writeBuffer(view.fragmentUniformBuffer, offset, view._f32_1);
+      }
     }
     view.chaosMode.setUnderwaterMode(false);
+
+    // Emissive flashes for standard/premium layouts
+    view._f32_1[0] = view.visualEffects.movementFlashTimer;
+    device.queue.writeBuffer(view.fragmentUniformBuffer, 96, view._f32_1);
+    view._f32_1[0] = view.visualEffects.lineClearFlashTimer;
+    device.queue.writeBuffer(view.fragmentUniformBuffer, 100, view._f32_1);
   }
 
   // Post-process uniforms


### PR DESCRIPTION
### 🎨 Visual Polish & "Juice": Block Emissive Pulses and Rim Lighting
Added dynamic visual feedback to the core game blocks themselves. Blocks now physically pulse with an emissive glow and bright rim lighting when reacting to player actions.

- **Movement Flash**: Blocks pulse gently whenever they are moved or rotated.
- **Line Clear Flash**: Blocks flash intensely when lines are cleared. The intensity scales based on the quality of the clear (e.g., number of lines, T-Spins, combos, back-to-backs).

This adds a significant tactile feel and "neon glass" juice to the game. 

### 🔧 Implementation Details
- Modifies the WebGPU fragment shaders (`pbrBlocks.ts`, `premiumBlocks.ts`, `underwaterBlocks.ts`) to calculate `dynamicRim` and `emissivePulse` using new uniform inputs.
- Extends the `VisualEffects` class (`effects.ts`) to manage fast-decaying `movementFlashTimer` and `lineClearFlashTimer` variables.
- Safely manages varying WebGPU `fragmentUniformBuffer` offsets (standard/premium use `96` and `100`, while underwater uses `128` and `132` due to its larger struct).
- Configures `onLineClear`, `onMove`, and `onRotate` inside `viewGameEvents.ts` to emit these flashes.

---
*PR created automatically by Jules for task [12309666405359619042](https://jules.google.com/task/12309666405359619042) started by @ford442*