### PR TITLE
feat(visuals): enhance ghost piece hologram with intense cyan scanlines

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -16,3 +16,4 @@
 - "Added 'Warp Surge' on big plays: tetrises and T-Spins now significantly distort the hyperspace tunnel background, making the big clears feel even more chaotic and impactful."
 - "Enhanced the Subliminal Reinforcement system to use bright white/cyan neon text shadows, added a snappy scale transform on flashes, and integrated a subtle Neon Bloom flash in the WebGPU pipeline during strong cues to increase the visceral impact of positive reinforcement."
 - "Verified all requested game feel and visual features are present. The Infinity lock resets, T-Spins, level-reactive backgrounds, and bloom/chromatic aberration on shockwaves have already been flawlessly implemented in the engine."
+- "Replaced the subtle white ghost scanlines with intense, cyan/blue colored holographic scan overlays (`vec3<f32>(0.2, 0.8, 1.0) * (scanEffect + horizontalScan) * 5.0`). This significantly enhances the 'neon hologram' vibe of the ghost piece!"

--- a/src/webgpu/shaders/main.ts
+++ b/src/webgpu/shaders/main.ts
@@ -322,7 +322,7 @@ export const Shaders = () => {
                                    + vec3<f32>(0.4, 0.85, 1.0) * fresnelTerm * 4.0; // Cyan/Blue rim
 
                     ghostFinal += vec3<f32>(ghostGlitch); // Glitch
-                    ghostFinal += vec3<f32>(scanEffect + horizontalScan); // Scan overlays
+                    ghostFinal += vec3<f32>(0.2, 0.8, 1.0) * (scanEffect + horizontalScan) * 5.0; // NEON BRICKLAYER: Colored, intense scan overlays
                     ghostFinal += vec3<f32>(gridPattern) * ghostColor * 0.6; // Grid pattern
 
                     // Digital noise sparkles


### PR DESCRIPTION
This PR completes a visual enhancement pass as the "Neon Bricklayer", focusing on the ghost piece shader.

### Changes
*   **WGSL Shader Polishing:** Modified the `GHOST PIECE LOGIC` in `src/webgpu/shaders/main.ts`. Changed the scanline overlays from a subtle white color addition to a multiplied, intense cyan/blue colored scanline (`vec3<f32>(0.2, 0.8, 1.0) * (scanEffect + horizontalScan) * 5.0`). This dramatically increases the "Juice" and sells the Cyberpunk/Neon hologram aesthetic much better.
*   **Journal Updated:** Logged the specific changes in `neon_bricklayers_journal.md`.

### Verification
*   Tests pass successfully (`npm run test`).
*   Build completes successfully (`npm run build:all`).
*   No regressions in shader compilation or rendering logic.

---
*PR created automatically by Jules for task [13135250974188858905](https://jules.google.com/task/13135250974188858905) started by @ford442*