### PR TITLE
Enhanced Line Clear Juice and Laser Effect

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -259,7 +259,9 @@ export default class View {
     materialAwareBloom: 0,
     screenResolution: [0, 0] as [number, number],
     aberrationPulse: 0,  // hard drop 300ms chromatic spike -> u_aberrationPulse
-    dangerLevel: 0       // board height fill ratio 0-1 for danger vignette (postProcess)
+    dangerLevel: 0,      // board height fill ratio 0-1 for danger vignette (postProcess)
+    lineClearLaserY: [0, 0, 0, 0] as [number, number, number, number],
+    lineClearLaserIntensity: 0
   };
 
   constructor(element: HTMLElement, width: number, height: number, rows: number, coloms: number, nextPieceContext: CanvasRenderingContext2D, holdPieceContext: CanvasRenderingContext2D) {
@@ -694,7 +696,7 @@ export default class View {
         primitive: { topology: 'triangle-list' }
     });
 
-    this.postProcessUniformBuffer = this.device.createBuffer({ size: 144, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    this.postProcessUniformBuffer = this.device.createBuffer({ size: 160, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
     this.sampler = this.device.createSampler({ magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge' });
 
     this.offscreenTexture = this.device.createTexture({

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -28,6 +28,10 @@ export class VisualEffects {
     movementFlashTimer: number = 0;
     lineClearFlashTimer: number = 0;
 
+    // Supernova Line Clear Laser state
+    lineClearLaserY: Float32Array = new Float32Array([0.0, 0.0, 0.0, 0.0]);
+    lineClearLaserIntensity: number = 0.0;
+
     // Ghost/shadow vertical light-trail state (animates 200ms after piece move)
     ghostTrailTimer: number = 0;
     private _lastActiveY: number = -999;
@@ -88,6 +92,15 @@ export class VisualEffects {
         const aberrationDecay = 1.0 / (1.0 + dt * 3.0);
         this.shakeIntensity *= Math.exp(-dt * 15.0);
         this.aberrationIntensity *= aberrationDecay;
+
+        // Supernova Line Clear Laser decay (rapid exponential decay targeting ~150ms)
+        if (this.lineClearLaserIntensity > 0) {
+            this.lineClearLaserIntensity *= Math.exp(-dt / 0.06);
+            if (this.lineClearLaserIntensity < 0.005) {
+                this.lineClearLaserIntensity = 0;
+                this.lineClearLaserY.fill(0);
+            }
+        }
 
         // Warp surge decay
         this.warpSurge *= 1.0 / (1.0 + dt * 1.5);
@@ -214,6 +227,23 @@ export class VisualEffects {
     triggerNeonBloomFlash(strength: number = 1.0): void {
         this.neonBloomIntensity += strength;
         this.neonBloomIntensity = Math.min(this.neonBloomIntensity, 3.0); // Cap max bloom explosion
+    }
+
+    triggerLineClearLaser(lines: number[], strength: number = 1.0): void {
+        this.lineClearLaserIntensity = strength;
+        this.lineClearLaserY.fill(0); // Clear previous
+
+        // Map world Y back to UV Y
+        const camY = -20.0;
+        const camZ = 75.0;
+        const fov = (35 * Math.PI) / 180;
+        const visibleHeight = 2.0 * Math.tan(fov / 2.0) * camZ;
+
+        for (let i = 0; i < Math.min(lines.length, 4); i++) {
+            const worldY = lines[i] * -2.2;
+            const uvY = 0.5 - (worldY - camY) / visibleHeight;
+            this.lineClearLaserY[i] = uvY;
+        }
     }
 
     triggerGlitch(intensity: number): void {

--- a/src/webgpu/particles.ts
+++ b/src/webgpu/particles.ts
@@ -228,8 +228,8 @@ export class ParticleSystem {
         worldY: number,
         themeColors: Record<number, number[]> | null
     ): void {
-        const life = 0.58 + Math.random() * 0.04; // ~0.6s fade
-        const baseScale = 0.18; // small base; stretch will make them thin shards
+        const life = 0.65 + Math.random() * 0.15; // JUICE: slightly longer life for vapor trail
+        const baseScale = 0.28; // JUICE: larger base for chunkier plasma shards
 
         for (let i = 0; i < clearedCols.length; i++) {
             const col = clearedCols[i];
@@ -258,14 +258,15 @@ export class ParticleSystem {
             }
 
             // Emit 3-5 shards per cleared block position for a nice burst density
-            const shardsPerBlock = 4;
+            const shardsPerBlock = 5; // JUICE: more shards per block
             for (let s = 0; s < shardsPerBlock; s++) {
                 // Directional outward from center of board (left side -> left, right side -> right)
                 const outward = (col < 4.5) ? -1.0 : 1.0;
-                const speed = 18.0 + this.rand(8.0, 22.0);
-                const vx = outward * speed + this.rand(-4.0, 4.0); // main horizontal burst + jitter
-                const vy = this.rand(-14.0, 14.0); // vertical spread for "outward" feel from the row
-                const vz = this.rand(-6.0, 6.0) * 0.3;
+                // JUICE: Massively increased speed for explosive row vaporization
+                const speed = 40.0 + this.rand(20.0, 40.0);
+                const vx = outward * speed * 1.2 + this.rand(-10.0, 10.0); // Stronger horizontal burst
+                const vy = this.rand(-20.0, 20.0); // More vertical spread
+                const vz = this.rand(-8.0, 8.0) * 0.5;
 
                 // Slight positional offset around the block for organic burst origin
                 const ox = this.rand(-0.6, 0.6);
@@ -276,7 +277,7 @@ export class ParticleSystem {
                     vx, vy, vz,
                     color,
                     life,
-                    baseScale + Math.random() * 0.08
+                    baseScale + Math.random() * 0.12
                 );
             }
         }

--- a/src/webgpu/postProcessUniforms.ts
+++ b/src/webgpu/postProcessUniforms.ts
@@ -53,14 +53,16 @@ struct PostProcessUniforms {
     screenHeight: f32,      // 88
     _pad3: f32,             // 92
     
-    // Frame 5-8: Reserved (offset 96-144)
+    // Frame 5-9: Reserved (offset 96-160)
     dangerLevel: f32,       // 96  (board height fill ratio 0-1, contracts vignette inner radius as stack rises)
     aberrationPulse: f32,   // 100 (short-lived hard-drop chromatic aberration spike, 300ms exp decay)
     levelUpFlashColor: vec3f,   // 104 (r,g,b from theme.backgroundColors[0] for level-up additive burn)
     levelUpFlashIntensity: f32, // 116 (high opacity -> 0 over exactly 400ms)
     gameOverKaleidoTime: f32,   // 120 (2s spinning 6-triangle kaleidoscope mirror on final board state + fade; post-process UV)
-    reserved2: vec4f,       // 124
-    reserved3: vec2f,       // 136
+    _pad4: f32,                 // 124 (pad to 16-byte boundary for vec4f)
+    lineClearLaserY: vec4f,     // 128 (up to 4 y-coordinates for line clear laser beams)
+    lineClearLaserIntensity: f32, // 144
+    // Struct size is automatically padded to 160 by WGSL (multiple of 16)
 };
 `;
 
@@ -106,11 +108,15 @@ export interface PostProcessUniformData {
 
   // Game over: 2s spinning 6-segment kaleidoscope mirror on captured final board state (post-process UV transform)
   gameOverKaleidoTime?: number;
+
+  // Supernova line clear laser effect
+  lineClearLaserY?: [number, number, number, number];
+  lineClearLaserIntensity?: number;
 }
 
 export class PostProcessUniformManager {
-  // 144 bytes = 9 vec4s (with padding)
-  private data = new Float32Array(36); // 36 floats = 144 bytes
+  // 160 bytes = 10 vec4s (with padding)
+  private data = new Float32Array(40); // 40 floats = 160 bytes
   
   // Default values
   defaults: PostProcessUniformData = {
@@ -134,6 +140,8 @@ export class PostProcessUniformManager {
     levelUpFlashColor: [0.2, 0.6, 1.0],
     levelUpFlashIntensity: 0,
     gameOverKaleidoTime: 0,
+    lineClearLaserY: [0, 0, 0, 0],
+    lineClearLaserIntensity: 0,
   };
 
   /**
@@ -188,10 +196,19 @@ export class PostProcessUniformManager {
     this.data[29] = (v as any).levelUpFlashIntensity || 0;
     // gameOverKaleidoTime at 120 (float 30) - 2s board kaleidoscope spin + fade in post-process
     this.data[30] = (v as any).gameOverKaleidoTime || 0;
-    for (let i = 31; i < 36; i++) {
-      this.data[i] = 0;
-    }
     
+    this.data[31] = 0; // _pad4 at 124
+
+    const laserY = (v as any).lineClearLaserY || [0, 0, 0, 0];
+    this.data[32] = laserY[0]; // offset 128
+    this.data[33] = laserY[1];
+    this.data[34] = laserY[2];
+    this.data[35] = laserY[3];
+    this.data[36] = (v as any).lineClearLaserIntensity || 0; // offset 144
+    this.data[37] = 0;
+    this.data[38] = 0;
+    this.data[39] = 0;
+
     return this.data;
   }
 

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -311,6 +311,24 @@ export const EnhancedPostProcessShaders = () => {
                 color *= kaleidoFade;
             }
 
+            // JUICE: Supernova Line Clear Laser
+            let laserIntensity = uniforms.lineClearLaserIntensity;
+            if (laserIntensity > 0.01) {
+                var laserGlow = 0.0;
+                for (var i: i32 = 0; i < 4; i++) {
+                    let yPos = uniforms.lineClearLaserY[i];
+                    if (yPos > 0.01) {
+                        let distY = abs(uv.y - yPos);
+                        laserGlow += 1.0 / (distY * 80.0 + 1.0) * exp(-distY * 10.0);
+                        if (distY < 0.02) {
+                            color.b += 0.2 * laserIntensity;
+                        }
+                    }
+                }
+                let laserColor = vec3<f32>(0.2, 0.8, 1.0) * laserIntensity * 2.5;
+                color += laserColor * laserGlow;
+            }
+
             // HDR tone mapping
             color = color / (color + vec3<f32>(1.0));
             color = sqrt(color); // Fast gamma approx

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -354,6 +354,24 @@ export const MaterialAwarePostProcessShaders = () => {
                 color *= kaleidoFade;
             }
 
+            // JUICE: Supernova Line Clear Laser
+            let laserIntensity = uniforms.lineClearLaserIntensity;
+            if (laserIntensity > 0.01) {
+                var laserGlow = 0.0;
+                for (var i: i32 = 0; i < 4; i++) {
+                    let yPos = uniforms.lineClearLaserY[i];
+                    if (yPos > 0.01) {
+                        let distY = abs(uv.y - yPos);
+                        laserGlow += 1.0 / (distY * 80.0 + 1.0) * exp(-distY * 10.0);
+                        if (distY < 0.02) {
+                            color.b += 0.2 * laserIntensity;
+                        }
+                    }
+                }
+                let laserColor = vec3<f32>(0.2, 0.8, 1.0) * laserIntensity * 2.5;
+                color += laserColor * laserGlow;
+            }
+
             // HDR tone mapping
             color = color / (color + vec3<f32>(1.0));
             color = sqrt(color); // Fast gamma approx

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -237,6 +237,27 @@ export const PostProcessShaders = () => {
                 color *= kaleidoFade;
             }
 
+            // JUICE: Supernova Line Clear Laser
+            let laserIntensity = uniforms.lineClearLaserIntensity;
+            if (laserIntensity > 0.01) {
+                var laserGlow = 0.0;
+                for (var i: i32 = 0; i < 4; i++) {
+                    let yPos = uniforms.lineClearLaserY[i];
+                    if (yPos > 0.01) {
+                        let distY = abs(uv.y - yPos);
+                        // Sharp falloff for intense laser beam look
+                        laserGlow += 1.0 / (distY * 80.0 + 1.0) * exp(-distY * 10.0);
+                        // Add horizontal tear/glitch near the laser
+                        if (distY < 0.02) {
+                            color.b += 0.2 * laserIntensity;
+                        }
+                    }
+                }
+                // Cyan/white beam color
+                let laserColor = vec3<f32>(0.2, 0.8, 1.0) * laserIntensity * 2.5;
+                color += laserColor * laserGlow;
+            }
+
             if (!inBounds) {
                 return vec4<f32>(0.0, 0.0, 0.0, 1.0);
             }

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -77,6 +77,10 @@ export function onLineClear(view: any, lines: number[], tSpin: boolean = false, 
   const bloomIntensity = 1.0 + lines.length * 0.5;
   view.visualEffects.triggerNeonBloomFlash(bloomIntensity);
 
+  // JUICE: Supernova Line Clear Laser
+  // Trigger a localized horizontal laser/plasma beam exactly on the cleared rows
+  view.visualEffects.triggerLineClearLaser(lines, 1.0 + lines.length * 0.5);
+
   // JUICE: Warp Surge on Big Plays
   // If it's a Tetris or T-Spin, heavily distort the background hyperspace tunnel.
   if (lines.length >= 4 || tSpin) {

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -337,6 +337,13 @@ function updatePostProcessUniforms(view: any, time: number) {
   // Game over kaleidoscope time (2s spin on final board in post-process kaleido UV)
   view._postProcessParams.gameOverKaleidoTime = view.visualEffects.gameOverKaleidoTimer || 0;
 
+  // Line clear laser uniforms
+  view._postProcessParams.lineClearLaserY[0] = view.visualEffects.lineClearLaserY[0];
+  view._postProcessParams.lineClearLaserY[1] = view.visualEffects.lineClearLaserY[1];
+  view._postProcessParams.lineClearLaserY[2] = view.visualEffects.lineClearLaserY[2];
+  view._postProcessParams.lineClearLaserY[3] = view.visualEffects.lineClearLaserY[3];
+  view._postProcessParams.lineClearLaserIntensity = view.visualEffects.lineClearLaserIntensity || 0;
+
   // Column heights (topmost row index per column, 0=top of board) for simple depth-based
   // soft shadows in pbrBlocks shader. Written directly here (per task) at 144+; no hot allocs
   // (reuse _f32_1). Reuses the pf already scanned above for dangerLevel.


### PR DESCRIPTION
This PR enhances the line-clear visual feedback in the WebGPU renderer by transforming line clears into explosive "supernova" events. It significantly increases the burst velocity and visual scale of the shard particles in `particles.ts`. Furthermore, it implements a localized horizontal laser/bloom spike exactly on the Y-coordinates of the cleared rows via the post-processing pipeline. The effect dynamically scales in intensity based on the number of lines cleared. The PR safely expands the uniform buffers to 160 bytes to adhere to WGSL's strict 16-byte alignment for the new parameters, eliminating WebGPU validation crashes.

---
*PR created automatically by Jules for task [15835987695040050881](https://jules.google.com/task/15835987695040050881) started by @ford442*