### PR TITLE
Enhance hard drop visual with chromatic aberration pulse

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -26,3 +26,4 @@
 - "Tuned Game Feel: Ensured Infinity lock delay mechanics feel generous but fair by resetting the lock timer up to 15 times on move/rotate. Verified SRS logic for smooth wall kicks and T-Spins."
 - "Ensured DAS (Delayed Auto Shift) and ARR (Auto Repeat Rate) are perfectly tuned for sub-50ms input latency."
 - "Verified that the maximum particle count is capped to prevent browser lag while maintaining high-impact visual explosions."
+- "Modified postProcess.ts and materialAwarePostProcess.ts to incorporate `aberrationPulse` so that hard drops look like they tear the screen apart by pushing Red and Blue color channels away!"

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -289,10 +289,18 @@ export const MaterialAwarePostProcessShaders = () => {
             let horizOffset = totalAberration + glitchOffset + shockwaveAberration;
             let vertAberration = totalAberration * (uv.y - 0.5) * 0.2 + (shockwaveAberration * 0.5);
 
+            // NEW: Hard-drop triggered short-lived chromatic aberration spike (u_aberrationPulse)
+            // 300ms exp decay (CPU side), separate per-channel RGB offsets for a sharp "spike" at impact.
+            // Positive/negative splits create classic red/cyan fringing that peaks then fades.
+            let pulse = uniforms.aberrationPulse;
+            let pulseR = pulse * 0.022;
+            let pulseG = pulse * 0.004;
+            let pulseB = pulse * -0.018;
+
             let baseSample = textureSample(myTexture, mySampler, finalUV);
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset, vertAberration)).r;
+            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR, vertAberration + pulseG * 0.6)).r;
             var g = baseSample.g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset, vertAberration)).b;
+            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB, vertAberration + pulseR * 0.4)).b;
             var color = vec3<f32>(r, g, b);
             let sampledAlpha = baseSample.a;
 

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -146,10 +146,19 @@ export const PostProcessShaders = () => {
             let horizOffset = totalAberration + glitchOffset + shockwaveAberration;
             let vertAberration = totalAberration * (uv.y - 0.5) * 0.2 + (shockwaveAberration * 0.5);
 
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset, vertAberration)).r;
-            var g = textureSample(myTexture, mySampler, finalUV).g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset, vertAberration)).b;
-            let a = textureSample(myTexture, mySampler, finalUV).a;
+            // NEW: Hard-drop triggered short-lived chromatic aberration spike (u_aberrationPulse)
+            // 300ms exp decay (CPU side), separate per-channel RGB offsets for a sharp "spike" at impact.
+            // Positive/negative splits create classic red/cyan fringing that peaks then fades.
+            let pulse = uniforms.aberrationPulse;
+            let pulseR = pulse * 0.022;
+            let pulseG = pulse * 0.004;
+            let pulseB = pulse * -0.018;
+
+            let baseSample = textureSample(myTexture, mySampler, finalUV);
+            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR, vertAberration + pulseG * 0.6)).r;
+            var g = baseSample.g;
+            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB, vertAberration + pulseR * 0.4)).b;
+            let a = baseSample.a;
 
             // Bloom-ish boost (optimized 5-tap tent filter)
             var color = vec3<f32>(r, g, b);


### PR DESCRIPTION
Enhance hard drop visual with chromatic aberration pulse

This commit updates `postProcess.ts` and `materialAwarePostProcess.ts`
to respect the `aberrationPulse` uniform driven by the game's effect
engine. This ensures that when a hard drop occurs, the RGB color
channels split violently on the screen and tear it apart, providing
massive visual impact, fulfilling the design intent of the Neon Bricklayer.

---
*PR created automatically by Jules for task [819381530568402297](https://jules.google.com/task/819381530568402297) started by @ford442*