### PR TITLE
Implement Black Hole Distortion Effect on Tetris Clears

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -27,3 +27,5 @@
 - "Ensured DAS (Delayed Auto Shift) and ARR (Auto Repeat Rate) are perfectly tuned for sub-50ms input latency."
 - "Verified that the maximum particle count is capped to prevent browser lag while maintaining high-impact visual explosions."
 - "Modified postProcess.ts and materialAwarePostProcess.ts to incorporate `aberrationPulse` so that hard drops look like they tear the screen apart by pushing Red and Blue color channels away!"
+
+- "Implemented a massive 'Black Hole' gravitational lensing distortion and cyan event horizon glow in the post-processing pipeline, triggered on Tetris clears, causing the entire board to suck inward into a singularity!"

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -20,6 +20,10 @@ export class VisualEffects {
     shockwaveCenter: number[] = [0.5, 0.5];
     shockwaveParams: number[] = [0.15, 0.08, 0.03, 2.0]; // width, strength, aberration, speed
 
+    // Black Hole state
+    blackHoleTime: number = 0;
+    blackHoleCenter: number[] = [0.5, 0.5];
+
     // Neon Bloom state
     neonBloomIntensity: number = 0;
     neonBloomBaseIntensity: number = 1.0;
@@ -151,6 +155,11 @@ export class VisualEffects {
         if (this.shakeIntensity < 0.01) this.shakeIntensity = 0;
         if (this.aberrationIntensity < 0.01) this.aberrationIntensity = 0;
 
+        if (this.blackHoleTime > 0) {
+            this.blackHoleTime += dt * 0.8;
+            if (this.blackHoleTime > 1.0) this.blackHoleTime = 0.0;
+        }
+
         if (this.shockwaveTimer > 0) {
             this.shockwaveTimer += dt * 0.8; // Speed
             if (this.shockwaveTimer > 1.0) this.shockwaveTimer = 0.0;
@@ -260,6 +269,11 @@ export class VisualEffects {
         this.triggerGlitch(0.8 + (level * 0.05));
         this.triggerAberration(0.5 + (level * 0.05));
         this.triggerShake(2.0 + (level * 0.2), 0.8);
+    }
+
+    triggerBlackHole(center: number[]): void {
+        this.blackHoleCenter = center;
+        this.blackHoleTime = 0.01;
     }
 
     triggerShockwave(center: number[], width: number = 0.15, strength: number = 0.08, aberration: number = 0.03, speed: number = 2.0): void {

--- a/src/webgpu/postProcessUniforms.ts
+++ b/src/webgpu/postProcessUniforms.ts
@@ -62,6 +62,8 @@ struct PostProcessUniforms {
     _pad4: f32,                 // 124 (pad to 16-byte boundary for vec4f)
     lineClearLaserY: vec4f,     // 128 (up to 4 y-coordinates for line clear laser beams)
     lineClearLaserIntensity: f32, // 144
+    blackHoleTime: f32,           // 148
+    blackHoleCenter: vec2f,       // 152
     // Struct size is automatically padded to 160 by WGSL (multiple of 16)
 };
 `;
@@ -112,6 +114,8 @@ export interface PostProcessUniformData {
   // Supernova line clear laser effect
   lineClearLaserY?: [number, number, number, number];
   lineClearLaserIntensity?: number;
+  blackHoleTime?: number;
+  blackHoleCenter?: [number, number];
 }
 
 export class PostProcessUniformManager {
@@ -142,6 +146,8 @@ export class PostProcessUniformManager {
     gameOverKaleidoTime: 0,
     lineClearLaserY: [0, 0, 0, 0],
     lineClearLaserIntensity: 0,
+    blackHoleTime: 0,
+    blackHoleCenter: [0.5, 0.5],
   };
 
   /**
@@ -205,9 +211,10 @@ export class PostProcessUniformManager {
     this.data[34] = laserY[2];
     this.data[35] = laserY[3];
     this.data[36] = (v as any).lineClearLaserIntensity || 0; // offset 144
-    this.data[37] = 0;
-    this.data[38] = 0;
-    this.data[39] = 0;
+    this.data[37] = (v as any).blackHoleTime || 0;
+    const bhCenter = (v as any).blackHoleCenter || [0.5, 0.5];
+    this.data[38] = bhCenter[0];
+    this.data[39] = bhCenter[1];
 
     return this.data;
   }

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -162,6 +162,29 @@ export const EnhancedPostProcessShaders = () => {
             let distortStrength = 0.08;
             let distortedUV = 0.5 + centeredUV * (1.0 + distSq * distortStrength);
             var finalUV = distortedUV;
+
+            // Black Hole Distortion Effect for Tetris/All Clears
+            if (uniforms.blackHoleTime > 0.001) {
+                let bhCenter = uniforms.blackHoleCenter;
+                let bhTime = uniforms.blackHoleTime;
+                let bhDiff = finalUV - bhCenter;
+                let bhDist = length(bhDiff);
+
+                // Exponential radius shrink as it decays
+                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+
+                if (bhDist < bhRadius && bhDist > 0.0) {
+                    let angle = atan2(bhDiff.y, bhDiff.x);
+                    // Faster spin towards the center and over time
+                    let spin = bhTime * 10.0 * (1.0 - bhDist / bhRadius);
+                    let newAngle = angle + spin;
+
+                    // Suck inwards (gravity)
+                    let suck = pow(bhDist / bhRadius, 2.0) * bhRadius;
+
+                    finalUV = bhCenter + vec2<f32>(cos(newAngle), sin(newAngle)) * suck;
+                }
+            }
             
             let inBounds = (distortedUV.x >= 0.0 && distortedUV.x <= 1.0 && 
                            distortedUV.y >= 0.0 && distortedUV.y <= 1.0);

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -212,6 +212,29 @@ export const MaterialAwarePostProcessShaders = () => {
             let distortStrength = 0.05;
             let distortedUV = 0.5 + centeredUV * (1.0 + distSq * distortStrength);
             var finalUV = distortedUV;
+
+            // Black Hole Distortion Effect for Tetris/All Clears
+            if (uniforms.blackHoleTime > 0.001) {
+                let bhCenter = uniforms.blackHoleCenter;
+                let bhTime = uniforms.blackHoleTime;
+                let bhDiff = finalUV - bhCenter;
+                let bhDist = length(bhDiff);
+
+                // Exponential radius shrink as it decays
+                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+
+                if (bhDist < bhRadius && bhDist > 0.0) {
+                    let angle = atan2(bhDiff.y, bhDiff.x);
+                    // Faster spin towards the center and over time
+                    let spin = bhTime * 10.0 * (1.0 - bhDist / bhRadius);
+                    let newAngle = angle + spin;
+
+                    // Suck inwards (gravity)
+                    let suck = pow(bhDist / bhRadius, 2.0) * bhRadius;
+
+                    finalUV = bhCenter + vec2<f32>(cos(newAngle), sin(newAngle)) * suck;
+                }
+            }
             
             let inBounds = (distortedUV.x >= 0.0 && distortedUV.x <= 1.0 && 
                            distortedUV.y >= 0.0 && distortedUV.y <= 1.0);

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -37,6 +37,29 @@ export const PostProcessShaders = () => {
             let distortedUV = 0.5 + centeredUV * (1.0 + distSq * distortStrength);
 
             var finalUV = distortedUV;
+
+            // Black Hole Distortion Effect for Tetris/All Clears
+            if (uniforms.blackHoleTime > 0.001) {
+                let bhCenter = uniforms.blackHoleCenter;
+                let bhTime = uniforms.blackHoleTime;
+                let bhDiff = finalUV - bhCenter;
+                let bhDist = length(bhDiff);
+
+                // Exponential radius shrink as it decays
+                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+
+                if (bhDist < bhRadius && bhDist > 0.0) {
+                    let angle = atan2(bhDiff.y, bhDiff.x);
+                    // Faster spin towards the center and over time
+                    let spin = bhTime * 10.0 * (1.0 - bhDist / bhRadius);
+                    let newAngle = angle + spin;
+
+                    // Suck inwards (gravity)
+                    let suck = pow(bhDist / bhRadius, 2.0) * bhRadius;
+
+                    finalUV = bhCenter + vec2<f32>(cos(newAngle), sin(newAngle)) * suck;
+                }
+            }
             let inBounds = (distortedUV.x >= 0.0 && distortedUV.x <= 1.0 && distortedUV.y >= 0.0 && distortedUV.y <= 1.0);
 
             // Game over kaleidoscope (must be early, before any textureSample using finalUV)
@@ -184,6 +207,22 @@ export const PostProcessShaders = () => {
             let bloomIntensity = smoothstep(0.0, knee * 2.0, contrib) * 3.2;  // lowered from 6.0
 
             color += glow * bloomIntensity;
+
+            // Darken the center of the black hole
+            if (uniforms.blackHoleTime > 0.001) {
+                let bhCenter = uniforms.blackHoleCenter;
+                let bhTime = uniforms.blackHoleTime;
+                let bhDiff = uv - bhCenter;
+                let bhDist = length(bhDiff);
+                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+                if (bhDist < bhRadius) {
+                    let darkFactor = smoothstep(0.0, bhRadius * 0.5, bhDist);
+                    color *= darkFactor;
+                    // Event horizon cyan glow
+                    let ring = smoothstep(bhRadius * 0.8, bhRadius, bhDist) * (1.0 - smoothstep(bhRadius, bhRadius * 1.2, bhDist));
+                    color += vec3<f32>(0.2, 0.8, 1.0) * ring * 2.0 * (1.0 - bhTime);
+                }
+            }
 
             // Optional softer secondary boost
             let luminance = dot(color, vec3<f32>(0.299, 0.587, 0.114));

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -76,6 +76,13 @@ export function onLineClear(view: any, lines: number[], tSpin: boolean = false, 
   let bloomIntensity = 0.7;
   if (lines.length >= 4 || tSpin || combo >= 5) {
     bloomIntensity = 2.0;
+    // Trigger Black Hole on Tetris or huge clears
+    if (lines.length >= 4) {
+      // Epicenter is the middle of the cleared lines
+      const midY = lines[Math.floor(lines.length / 2)] * -2.2;
+      const uvY = (Math.abs(midY) + 2.2) / 44.0;
+      view.visualEffects.triggerBlackHole([0.5, uvY]);
+    }
   } else if (lines.length === 2 || lines.length === 3) {
     bloomIntensity = 1.3;
   }


### PR DESCRIPTION
Adds a visceral 'Black Hole' gravitational lensing distortion and cyan event horizon glow in the post-processing pipeline. The effect is triggered on Tetris clears, causing the entire board to suck inward into a singularity, satisfying the Neon Bricklayer graphics enhancement directives.

---
*PR created automatically by Jules for task [12142808901977961479](https://jules.google.com/task/12142808901977961479) started by @ford442*