### PR TITLE
Fix gold/glass block texture sampling (#304)

### DIFF
--- a/src/webgpu/blockTexture.ts
+++ b/src/webgpu/blockTexture.ts
@@ -82,6 +82,8 @@ export interface BlockTextureConfig {
   subregionWidth?: number;
   /** Height of subregion (for 'subregion' mode) */
   subregionHeight?: number;
+  /** Inset inside the subregion to avoid atlas hinge seams (0.0 - 0.2) */
+  subregionInset?: number;
   
   // Material detection configuration
   /** Method to use for detecting metal vs glass regions */
@@ -112,6 +114,7 @@ export const DEFAULT_BLOCK_TEXTURE_CONFIG: BlockTextureConfig = {
   subregionY: 0.193,
   subregionWidth: 0.247,
   subregionHeight: 0.446,
+  subregionInset: 0.04,
   materialDetectionMode: 'warmth',
   metalThresholdLow: 0.05,
   metalThresholdHigh: 0.20,

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -206,22 +206,42 @@ export const PBRBlockShaders = () => {
             // are small enough on screen that implicit LOD selection can soften the gold/glass detail.
             let texColor = textureSampleLevel(blockTexture, blockSampler, texUV, 0.0);
             
-            // Extract material masks using configurable method
-            let masks = extractMaterialMask(texColor.rgb);
-            let metalMask = masks.x;
-            let glassMask = masks.y;
+            // Per-pixel warmth masks (used for low-mix / PBR fallback paths).
+            let textureMasks = extractMaterialMask(texColor.rgb);
+            let textureMetalMask = textureMasks.x;
+            let textureGlassMask = textureMasks.y;
+
+            // Geometric frame mask — matches the reference go.1ink.us build.
+            // Gold frame lives on the UV perimeter; stained-glass window is the interior.
+            // Per-pixel warmth detection is unreliable on block.png edge pixels.
+            let distX = min(vUV.x, 1.0 - vUV.x);
+            let distY = min(vUV.y, 1.0 - vUV.y);
+            let distEdge = min(distX, distY);
+            let borderThickness = 0.15;
+            let glassMaskGeo = smoothstep(borderThickness - 0.02, borderThickness, distEdge);
+            let metalMaskGeo = 1.0 - glassMaskGeo;
 
             let textureMix = fUniforms.textureMix;
             // Border frame always samples block.png gold/crystal detail at full strength
             let isBorderBlock = vWorldPos.x < -0.8 || vWorldPos.x > 21.0
                              || vWorldPos.y > 1.5 || vWorldPos.y < -44.5;
             let effectiveTextureMix = max(textureMix, select(0.0, 0.94, isBorderBlock));
+            let useAuthoredSampling = effectiveTextureMix > 0.45;
 
-            let materialBase = composeMaterialBaseColor(texColor.rgb, vColor.rgb, metalMask);
-            // Authored texture + piece tint (main.ts path); textureMix only gates the lighting branch.
-            var baseColor = mix(vColor.rgb, materialBase, clamp(effectiveTextureMix, 0.0, 1.0));
-            if (effectiveTextureMix > 0.45) {
-                baseColor = materialBase;
+            let metalMask = select(textureMetalMask, metalMaskGeo, useAuthoredSampling);
+            let glassMask = select(textureGlassMask, glassMaskGeo, useAuthoredSampling);
+
+            // Reference build: frame = pure texture gold, window = texture detail * piece tint.
+            let frameColor = texColor.rgb * 1.2;
+            let windowColor = texColor.rgb * (vColor.rgb + vec3f(0.2));
+            let authoredBase = mix(frameColor, windowColor, glassMaskGeo);
+            let textureBase = composeMaterialBaseColor(texColor.rgb, vColor.rgb, textureMetalMask);
+
+            var baseColor: vec3f;
+            if (useAuthoredSampling) {
+                baseColor = authoredBase;
+            } else {
+                baseColor = mix(vColor.rgb, textureBase, clamp(effectiveTextureMix, 0.0, 1.0));
             }
 
             let materialType = fUniforms.materialType;
@@ -235,8 +255,8 @@ export const PBRBlockShaders = () => {
             let nh128 = nh16 * nh16 * nh16 * nh16 * nh16 * nh16 * nh16 * nh16;
             let tightSpec = nh128;
 
-            if (effectiveTextureMix > 0.45) {
-                // Authored block.png path: gold frame + stained-glass crystal (matches main.ts)
+            if (useAuthoredSampling) {
+                // Authored block.png path: gold frame + stained-glass crystal (reference build)
                 let lightFactor = 0.25 + NdotL * 0.65;
                 let specularStrength = mix(0.04, 0.18, metalMask);
                 finalColor = baseColor * lightFactor + vec3f(tightSpec * specularStrength);
@@ -271,7 +291,10 @@ export const PBRBlockShaders = () => {
                     finalColor += vec3f(0.4, 0.65, 0.95) * edge3 * glassMask * 0.35;
                 }
 
-                finalAlpha = mix(0.82, 0.96, metalMask);
+                // Opaque gold frame; translucent glass window so the video portal shows through.
+                let edgeFresnel = 1.0 - NdotV;
+                let glassOpacity = mix(0.15, 0.80, edgeFresnel * edgeFresnel);
+                finalAlpha = mix(1.0, glassOpacity, glassMaskGeo);
             } else if (fUniforms.enablePBR < 0.5 || materialType == 0u) {
                 // Classic mode
                 let lightFactor = 0.4 + NdotL * 0.6;

--- a/src/webgpu/textureSampling.ts
+++ b/src/webgpu/textureSampling.ts
@@ -230,13 +230,16 @@ export function getSimpleTextureSamplingWGSL(): string {
     const sy = config.subregionY ?? 0.0;
     const sw = config.subregionWidth ?? 1.0;
     const sh = config.subregionHeight ?? 1.0;
+    const inset = config.subregionInset ?? 0.0;
     return `
 // Texture sampling: SUBREGION mode (${sx.toFixed(3)},${sy.toFixed(3)}) ${(sw * 100).toFixed(1)}%x${(sh * 100).toFixed(1)}%
 fn transformUVForSampling(uv: vec2<f32>) -> vec2<f32> {
     let texUV = clamp(vec2<f32>(uv.x, 1.0 - uv.y), vec2<f32>(0.0), vec2<f32>(1.0));
+    let inset = ${inset};
+    let innerUV = texUV * (1.0 - inset * 2.0) + inset;
     return vec2<f32>(
-        ${sx} + texUV.x * ${sw},
-        ${sy} + texUV.y * ${sh}
+        ${sx} + innerUV.x * ${sw},
+        ${sy} + innerUV.y * ${sh}
     );
 }
 

--- a/tests/shader-optimizations.test.ts
+++ b/tests/shader-optimizations.test.ts
@@ -59,11 +59,13 @@ describe('shader optimization updates', () => {
     expect(fragment).not.toContain('let materialAlpha = mix(0.85, 0.98, metalMask);');
   });
 
-  it('composes gold frame and tinted glass from authored texture masks', () => {
+  it('composes gold frame and tinted glass using geometric UV frame mask', () => {
     const { fragment } = PBRBlockShaders();
     expect(fragment).toContain('composeMaterialBaseColor');
-    expect(fragment).toContain('effectiveTextureMix > 0.45');
-    expect(fragment).toContain('finalAlpha = mix(0.82, 0.96, metalMask)');
+    expect(fragment).toContain('useAuthoredSampling');
+    expect(fragment).toContain('borderThickness = 0.15');
+    expect(fragment).toContain('let frameColor = texColor.rgb * 1.2');
+    expect(fragment).toContain('let glassOpacity = mix(0.15, 0.80');
     expect(fragment).toContain('isBorderBlock');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Issue #304: blocks on test.1ink.us/tetris-webgpu were rendering as flat grey instead of the gold frame + stained-glass crystal look visible on the reference build at go.1ink.us/tetris.

## Root cause

Two separate problems were compounding:

1. **Wrong material split** — The PBR shader used per-pixel warmth/luminance detection (`extractMaterialMask`) to decide gold vs glass. Pixel analysis shows this fails on `block.png` edge pixels (gold-colored hinge areas get `metalMask ≈ 0`), so the gold frame never appears and the interior reads as flat grey crystal.

2. **Glass too opaque** — The authored path set `finalAlpha = mix(0.82, 0.96, metalMask)`, keeping the glass window at 82% opacity and blocking the background video portal.

The reference build (go.1ink.us) uses a **geometric UV frame mask** instead: gold on the face perimeter, tinted glass in the interior, with window alpha around 0.15–0.80.

## Fix

Align `pbrBlocks.ts` authored sampling path with the reference shader:

- **Geometric frame mask** (`borderThickness = 0.15`) — stable gold frame vs glass window split
- **Reference color model** — `frameColor = texColor * 1.2`, `windowColor = texColor * (pieceColor + 0.2)`
- **Fresnel glass alpha** — `mix(0.15, 0.80, fresnel²)` on the window so video shows through; frame stays opaque
- **Subregion inset (4%)** — keeps UV edges off dark atlas hinge seams when sampling the middle tile from the 2816×1536 `block.png`

Per-pixel warmth masks are retained for low-`textureMix` / PBR fallback paths.

## Testing

- `npm test` — all 57 tests pass
- Compare test.1ink.us vs go.1ink.us after deploy: gold frame on block edges, piece-colored translucent glass center, video visible through glass

Fixes #304
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed8b4b1-6d46-4e0b-bfae-aed4d02446f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed8b4b1-6d46-4e0b-bfae-aed4d02446f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subregion texture sampling with inset adjustment for improved block texture precision.
  * Introduced geometric frame masks and Fresnel-based opacity effects for enhanced glass and metal rendering.

* **Bug Fixes**
  * Improved shader logic for transitions between authored texture and geometric fallback rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->