### PR TITLE
Add WebGL2 fallback renderer for image-sampled blocks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import Game from "./src/game.js";
-import View from "./src/viewWebGPU.js";
+import { createView, getRendererPreference } from "./src/view/createView.js";
 import Controller from "./src/controller.js";
 import SoundManager from "./src/sound.js";
 import { SubliminalReinforcement } from './src/effects/subliminalReinforcement.js';
@@ -175,7 +175,7 @@ uiContainer.innerHTML = `
   const nextPieceCtx = (document.getElementById('next-piece-canvas') as HTMLCanvasElement).getContext('2d')!;
   const holdPieceCtx = (document.getElementById('hold-piece-canvas') as HTMLCanvasElement).getContext('2d')!;
 
-  const view = await View.create(
+  const view = await createView(
       document.body,
       window.innerWidth,
       window.innerHeight,
@@ -184,6 +184,8 @@ uiContainer.innerHTML = `
       nextPieceCtx,
       holdPieceCtx
   );
+
+  console.info(`Tetris renderer: ${view.rendererName} (preference: ${getRendererPreference()})`);
 
   // Connect game to view for reactive events
   game.view = view;

--- a/scripts/capture-screenshot.mjs
+++ b/scripts/capture-screenshot.mjs
@@ -1,0 +1,56 @@
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+
+const baseUrl = process.argv[2] || 'http://127.0.0.1:4173/tetris-webgpu/';
+const outDir = process.argv[3] || '/opt/cursor/artifacts/screenshots';
+const renderer = process.argv[4] || 'webgl2';
+const theme = process.argv[5] || 'imageSampled';
+
+await mkdir(outDir, { recursive: true });
+
+const sep = baseUrl.includes('?') ? '&' : '?';
+const url = `${baseUrl}${sep}renderer=${renderer}`;
+
+const browser = await chromium.launch({
+  headless: true,
+  args: ['--ignore-gpu-blocklist', '--disable-dev-shm-usage', '--no-sandbox'],
+});
+
+const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+await page.waitForSelector('#canvaswebgpu', { timeout: 30000 });
+await page.waitForTimeout(1500);
+
+const themeButtons = {
+  imageSampled: '#image-sampled-theme',
+  gold: '#gold-theme',
+  glass: '#glass-theme',
+};
+if (themeButtons[theme]) {
+  await page.locator(themeButtons[theme]).click();
+  await page.waitForTimeout(800);
+}
+
+await page.locator('#start-button').click();
+await page.waitForTimeout(2000);
+for (let i = 0; i < 6; i++) {
+  await page.keyboard.press('ArrowDown');
+  await page.waitForTimeout(120);
+  await page.keyboard.press(' ');
+  await page.waitForTimeout(700);
+}
+await page.waitForTimeout(1500);
+
+const pagePath = `${outDir}/tetris-${renderer}-${theme}.png`;
+const canvasPath = `${outDir}/tetris-${renderer}-${theme}-canvas.png`;
+await page.screenshot({ path: pagePath });
+await page.locator('#canvaswebgpu').screenshot({ path: canvasPath });
+
+const stats = await page.evaluate(() => ({
+  renderer: window.view?.rendererName,
+  filled: window.game?.playfield?.filter?.((v) => v > 0).length ?? 0,
+  theme: window.view?.currentTheme?.materialTheme,
+}));
+console.log(JSON.stringify({ url, stats, pagePath, canvasPath }, null, 2));
+
+await browser.close();

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,5 +1,5 @@
 import Game from "./game.js";
-import View from "./viewWebGPU.js";
+import type { IView } from "./view/IView.js";
 import SoundManager from "./sound.js";
 import { TouchControls, TouchAction, addTouchControlStyles } from "./input/touchControls.js";
 import { SubliminalReinforcement } from "./effects/subliminalReinforcement.js";
@@ -13,8 +13,8 @@ type Action = 'left' | 'right' | 'down' | 'rotateCW' | 'rotateCCW' | 'hardDrop' 
 
 export default class Controller {
   game: Game;
-  view: View;
-  viewWebGPU: View;
+  view: IView;
+  viewWebGPU: IView;
   soundManager: SoundManager;
   isPlaying: boolean;
   isPaused: boolean = false;
@@ -81,7 +81,7 @@ export default class Controller {
   private lastLevel: number = 1;
   private touchControls: TouchControls | null = null;
 
-  constructor(game: Game, view: View, viewWebGPU: View, soundManager: SoundManager) {
+  constructor(game: Game, view: IView, viewWebGPU: IView, soundManager: SoundManager) {
     this.game = game;
     this.view = view;
     this.viewWebGPU = viewWebGPU;

--- a/src/view/IView.ts
+++ b/src/view/IView.ts
@@ -1,0 +1,38 @@
+import type { Themes } from '../webgpu/themes.js';
+
+/** Shared surface area used by Controller and index.ts for either renderer backend. */
+export interface IView {
+  state: any;
+  rendererName: 'webgpu' | 'webgl2';
+  canvasWebGPU: HTMLCanvasElement;
+  currentTheme: any;
+  useGlitch?: boolean;
+  useReactiveVideo?: boolean;
+  useReactiveMusic?: boolean;
+  bloomEnabled?: boolean;
+  useWireframe?: boolean;
+
+  render(dt: number): void;
+  renderMainScreen(state: any): void;
+  renderEndScreen(state: any): void;
+  renderPauseScreen(): void;
+  renderPiece(ctx: CanvasRenderingContext2D, piece: any, blockSize?: number): void;
+  showFloatingText(text: string, subText?: string): void;
+
+  setTheme(themeName: keyof Themes): void;
+  setMaterialTheme?(themeName: string, pieceType?: number): void;
+  setPremiumVisualsPreset?(options?: Record<string, unknown>): void;
+  initReactiveMusic?(audioContext: AudioContext, masterGain: GainNode): void;
+
+  toggleGlitch?(): void;
+  toggleBloom?(enabled?: boolean): void;
+  setWireframe?(enabled: boolean): void;
+
+  onLineClear?(lines: number[], tSpin?: boolean, combo?: number, backToBack?: boolean, isAllClear?: boolean): void;
+  onLock?(isTSpin?: boolean): void;
+  onHardDrop?(x: number, ghostY: number, dropDist: number, colorIdx: number): void;
+  onMove?(x: number, y: number): void;
+  onRotate?(): void;
+  onHold?(): void;
+  triggerNeonBloomFlashEffects?(intensity: number): void;
+}

--- a/src/view/createView.ts
+++ b/src/view/createView.ts
@@ -1,0 +1,65 @@
+import type { IView } from './IView.js';
+import ViewWebGPU from '../viewWebGPU.js';
+import ViewWebGL2 from '../viewWebGL2/viewWebGL2.js';
+
+export type RendererPreference = 'auto' | 'webgpu' | 'webgl2';
+
+export function getRendererPreference(): RendererPreference {
+  const param = new URLSearchParams(window.location.search).get('renderer');
+  if (param === 'webgl2' || param === 'webgpu') return param;
+  const stored = localStorage.getItem('tetris_renderer');
+  if (stored === 'webgl2' || stored === 'webgpu') return stored;
+  return 'auto';
+}
+
+export function setRendererPreference(pref: RendererPreference): void {
+  if (pref === 'auto') {
+    localStorage.removeItem('tetris_renderer');
+  } else {
+    localStorage.setItem('tetris_renderer', pref);
+  }
+}
+
+async function createWebGPUView(
+  element: HTMLElement,
+  width: number,
+  height: number,
+  rows: number,
+  cols: number,
+  nextPieceContext: CanvasRenderingContext2D,
+  holdPieceContext: CanvasRenderingContext2D,
+): Promise<IView | null> {
+  if (!navigator.gpu) return null;
+  const view = await ViewWebGPU.create(element, width, height, rows, cols, nextPieceContext, holdPieceContext);
+  if (!(view as { isWebGPU?: { result: boolean } }).isWebGPU?.result) return null;
+  return view as unknown as IView;
+}
+
+export async function createView(
+  element: HTMLElement,
+  width: number,
+  height: number,
+  rows: number,
+  cols: number,
+  nextPieceContext: CanvasRenderingContext2D,
+  holdPieceContext: CanvasRenderingContext2D,
+): Promise<IView> {
+  const pref = getRendererPreference();
+
+  if (pref === 'webgl2') {
+    return ViewWebGL2.create(element, width, height, rows, cols, nextPieceContext, holdPieceContext);
+  }
+
+  if (pref === 'webgpu') {
+    const gpuView = await createWebGPUView(element, width, height, rows, cols, nextPieceContext, holdPieceContext);
+    if (gpuView) return gpuView;
+    console.warn('WebGPU requested but unavailable — falling back to WebGL2.');
+    return ViewWebGL2.create(element, width, height, rows, cols, nextPieceContext, holdPieceContext);
+  }
+
+  const gpuView = await createWebGPUView(element, width, height, rows, cols, nextPieceContext, holdPieceContext);
+  if (gpuView) return gpuView;
+
+  console.warn('WebGPU unavailable — using WebGL2 fallback renderer.');
+  return ViewWebGL2.create(element, width, height, rows, cols, nextPieceContext, holdPieceContext);
+}

--- a/src/view/playfieldInstances.ts
+++ b/src/view/playfieldInstances.ts
@@ -1,0 +1,73 @@
+import * as Matrix from 'gl-matrix';
+import { boardWorldX, boardWorldY } from '../webgpu/renderMetrics.js';
+
+export interface BlockInstance {
+  modelMatrix: Float32Array;
+  color: [number, number, number, number];
+}
+
+const _pos = Matrix.vec3.create();
+const _model = Matrix.mat4.create();
+
+/**
+ * Build world-space block instances for the playfield + interpolated active piece.
+ * Shared by WebGPU and WebGL2 renderers.
+ */
+export function buildPlayfieldInstances(
+  state: any,
+  currentTheme: any,
+  visualX: number,
+  visualY: number,
+): BlockInstance[] {
+  const instances: BlockInstance[] = [];
+  const { playfield, activePiece } = state;
+  if (!playfield) return instances;
+
+  for (let row = 0; row < playfield.length; row++) {
+    for (let col = 0; col < playfield[row].length; col++) {
+      const value = playfield[row][col];
+      if (!value) continue;
+
+      const colorIndex = Math.abs(value);
+      const alpha = value < 0 ? 0.3 : 0.9;
+      const color = currentTheme[colorIndex] || currentTheme[0];
+      const rgba: [number, number, number, number] = [color[0], color[1], color[2], alpha];
+
+      let useVisual = false;
+      if (activePiece) {
+        const relX = col - activePiece.x;
+        const relY = row - activePiece.y;
+        if (
+          relY >= 0 &&
+          relY < activePiece.blocks.length &&
+          relX >= 0 &&
+          relX < activePiece.blocks[0].length &&
+          activePiece.blocks[relY][relX] !== 0 &&
+          value > 0
+        ) {
+          useVisual = true;
+        }
+      }
+
+      Matrix.mat4.identity(_model);
+      if (useVisual && activePiece) {
+        const relX = col - activePiece.x;
+        const relY = row - activePiece.y;
+        _pos[0] = boardWorldX(visualX + relX);
+        _pos[1] = boardWorldY(visualY + relY);
+      } else {
+        _pos[0] = boardWorldX(col);
+        _pos[1] = boardWorldY(row);
+      }
+      _pos[2] = 0;
+      Matrix.mat4.translate(_model, _model, _pos);
+
+      instances.push({
+        modelMatrix: new Float32Array(_model),
+        color: rgba,
+      });
+    }
+  }
+
+  return instances;
+}

--- a/src/viewWebGL2/blockShadersGLSL.ts
+++ b/src/viewWebGL2/blockShadersGLSL.ts
@@ -1,0 +1,109 @@
+import { getSubregionUVTransformGLSL } from './textureSamplingGLSL.js';
+
+export function createBlockShaderSources(): { vertex: string; fragment: string } {
+  const uvTransform = getSubregionUVTransformGLSL();
+
+  const vertex = `#version 300 es
+precision highp float;
+
+layout(location = 0) in vec3 aPosition;
+layout(location = 1) in vec3 aNormal;
+layout(location = 2) in vec2 aUV;
+
+uniform mat4 u_viewProjection;
+uniform mat4 u_model;
+uniform mat4 u_normalMatrix;
+uniform vec4 u_color;
+
+out vec3 vNormal;
+out vec4 vColor;
+out vec2 vUV;
+out vec3 vWorldPos;
+
+void main() {
+  vec4 worldPos = u_model * vec4(aPosition, 1.0);
+  vWorldPos = worldPos.xyz;
+  gl_Position = u_viewProjection * worldPos;
+  vNormal = mat3(u_normalMatrix) * aNormal;
+  vColor = u_color;
+  vUV = aUV;
+}`;
+
+  const fragment = `#version 300 es
+precision highp float;
+
+in vec3 vNormal;
+in vec4 vColor;
+in vec2 vUV;
+in vec3 vWorldPos;
+
+uniform vec3 u_lightPos;
+uniform vec3 u_eyePos;
+uniform float u_textureMix;
+uniform int u_materialType;
+uniform sampler2D u_blockTexture;
+
+out vec4 outColor;
+
+${uvTransform}
+
+void main() {
+  vec3 N = normalize(vNormal);
+  vec3 V = normalize(u_eyePos - vWorldPos);
+  vec3 L = normalize(u_lightPos - vWorldPos);
+  vec3 H = normalize(L + V);
+  float NdotL = max(dot(N, L), 0.0);
+  float NdotV = max(dot(N, V), 0.0);
+  float NdotH = max(dot(N, H), 0.0);
+
+  vec2 texUV = transformUVForSampling(vUV);
+  vec4 texColor = texture(u_blockTexture, texUV);
+
+  float distX = min(vUV.x, 1.0 - vUV.x);
+  float distY = min(vUV.y, 1.0 - vUV.y);
+  float distEdge = min(distX, distY);
+  float borderThickness = 0.15;
+  float glassMask = smoothstep(borderThickness - 0.02, borderThickness, distEdge);
+
+  vec3 frameColor = texColor.rgb * 1.2;
+  vec3 windowColor = texColor.rgb * (vColor.rgb * 1.25 + vec3(0.18));
+  vec3 authoredBase = mix(frameColor, windowColor, glassMask);
+  vec3 baseColor = mix(vColor.rgb, authoredBase, clamp(u_textureMix, 0.0, 1.0));
+
+  float lightFactor = 0.38 + NdotL * 0.62;
+  float nh2 = NdotH * NdotH;
+  float nh4 = nh2 * nh2;
+  float nh16 = nh4 * nh4;
+  float tightSpec = nh16 * nh16 * nh16 * nh16;
+  float metalMask = 1.0 - glassMask;
+  float specularStrength = mix(0.04, 0.18, metalMask);
+  vec3 finalColor = baseColor * lightFactor + vec3(tightSpec * specularStrength);
+
+  if (glassMask > 0.2) {
+    float diffCenter = length(vUV - vec2(0.5));
+    float centerGlow = clamp((0.2025 - diffCenter * diffCenter) / 0.1225, 0.0, 1.0);
+    finalColor += vColor.rgb * 0.06 * centerGlow * glassMask;
+  }
+
+  float edgeFresnel = 1.0 - NdotV;
+  float fresnelSq = edgeFresnel * edgeFresnel;
+  float glassMin = 0.58;
+  float glassMax = 0.90;
+  if (u_materialType == 1) {
+    glassMin = 0.78;
+    glassMax = 0.98;
+  } else if (u_materialType == 3) {
+    glassMin = 0.48;
+    glassMax = 0.82;
+  } else if (u_materialType == 2) {
+    glassMin = 0.72;
+    glassMax = 0.96;
+  }
+  float glassOpacity = mix(glassMin, glassMax, fresnelSq);
+  float alpha = mix(1.0, glassOpacity, glassMask) * vColor.a;
+
+  outColor = vec4(clamp(finalColor, 0.0, 1.0), alpha);
+}`;
+
+  return { vertex, fragment };
+}

--- a/src/viewWebGL2/glBlockRenderer.ts
+++ b/src/viewWebGL2/glBlockRenderer.ts
@@ -1,0 +1,183 @@
+import { CubeData } from '../webgpu/geometry.js';
+import { resolveBlockTextureUrl } from '../webgpu/blockTexture.js';
+import { createBlockShaderSources } from './blockShadersGLSL.js';
+import { textureLogger } from '../utils/logger.js';
+
+function compileShader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error('Failed to create shader');
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(shader) ?? 'unknown';
+    gl.deleteShader(shader);
+    throw new Error(`Shader compile error: ${log}`);
+  }
+  return shader;
+}
+
+function createProgram(gl: WebGL2RenderingContext, vertexSrc: string, fragmentSrc: string): WebGLProgram {
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vertexSrc);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSrc);
+  const program = gl.createProgram();
+  if (!program) throw new Error('Failed to create program');
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(program) ?? 'unknown';
+    gl.deleteProgram(program);
+    throw new Error(`Program link error: ${log}`);
+  }
+  return program;
+}
+
+export class GLBlockRenderer {
+  private gl: WebGL2RenderingContext;
+  private program!: WebGLProgram;
+  private vao!: WebGLVertexArrayObject;
+  private vertexCount = 0;
+  private texture!: WebGLTexture;
+  private authoredTextureLoaded = false;
+
+  private u_viewProjection!: WebGLUniformLocation;
+  private u_model!: WebGLUniformLocation;
+  private u_normalMatrix!: WebGLUniformLocation;
+  private u_color!: WebGLUniformLocation;
+  private u_lightPos!: WebGLUniformLocation;
+  private u_eyePos!: WebGLUniformLocation;
+  private u_textureMix!: WebGLUniformLocation;
+  private u_materialType!: WebGLUniformLocation;
+
+  private _identity = new Float32Array([
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+  ]);
+
+  constructor(gl: WebGL2RenderingContext) {
+    this.gl = gl;
+  }
+
+  async init(moduleUrl: string): Promise<boolean> {
+    const gl = this.gl;
+    const { vertex, fragment } = createBlockShaderSources();
+    this.program = createProgram(gl, vertex, fragment);
+
+    this.u_viewProjection = gl.getUniformLocation(this.program, 'u_viewProjection')!;
+    this.u_model = gl.getUniformLocation(this.program, 'u_model')!;
+    this.u_normalMatrix = gl.getUniformLocation(this.program, 'u_normalMatrix')!;
+    this.u_color = gl.getUniformLocation(this.program, 'u_color')!;
+    this.u_lightPos = gl.getUniformLocation(this.program, 'u_lightPos')!;
+    this.u_eyePos = gl.getUniformLocation(this.program, 'u_eyePos')!;
+    this.u_textureMix = gl.getUniformLocation(this.program, 'u_textureMix')!;
+    this.u_materialType = gl.getUniformLocation(this.program, 'u_materialType')!;
+
+    const cube = CubeData();
+    this.vertexCount = cube.positions.length / 3;
+
+    const vao = gl.createVertexArray();
+    if (!vao) throw new Error('Failed to create VAO');
+    this.vao = vao;
+    gl.bindVertexArray(vao);
+
+    const posBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, cube.positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+    const normalBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normalBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, cube.normals, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 0, 0);
+
+    const uvBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, cube.uvs, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribPointer(2, 2, gl.FLOAT, false, 0, 0);
+
+    gl.bindVertexArray(null);
+
+    this.texture = gl.createTexture()!;
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+
+    try {
+      const url = resolveBlockTextureUrl(moduleUrl);
+      textureLogger.info('[WebGL2] Loading block texture from:', url);
+      const image = await loadImage(url);
+      gl.bindTexture(gl.TEXTURE_2D, this.texture);
+      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+      gl.generateMipmap(gl.TEXTURE_2D);
+      this.authoredTextureLoaded = true;
+      textureLogger.info('[WebGL2] Block texture loaded:', image.width, 'x', image.height);
+    } catch (e) {
+      textureLogger.error('[WebGL2] Block texture load failed:', e);
+      gl.bindTexture(gl.TEXTURE_2D, this.texture);
+      const pixel = new Uint8Array([220, 220, 220, 255]);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+      this.authoredTextureLoaded = false;
+    }
+
+    gl.enable(gl.DEPTH_TEST);
+    gl.depthFunc(gl.LEQUAL);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    return this.authoredTextureLoaded;
+  }
+
+  get authoredLoaded(): boolean {
+    return this.authoredTextureLoaded;
+  }
+
+  draw(
+    viewProjection: Float32Array,
+    eyePos: [number, number, number],
+    lightPos: [number, number, number],
+    textureMix: number,
+    materialType: number,
+    instances: Array<{ modelMatrix: Float32Array; color: [number, number, number, number] }>,
+  ): void {
+    const gl = this.gl;
+    gl.useProgram(this.program);
+    gl.bindVertexArray(this.vao);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+
+    gl.uniformMatrix4fv(this.u_viewProjection, false, viewProjection);
+    gl.uniform3f(this.u_lightPos, lightPos[0], lightPos[1], lightPos[2]);
+    gl.uniform3f(this.u_eyePos, eyePos[0], eyePos[1], eyePos[2]);
+    gl.uniform1f(this.u_textureMix, textureMix);
+    gl.uniform1i(this.u_materialType, materialType);
+
+    for (const inst of instances) {
+      gl.uniformMatrix4fv(this.u_model, false, inst.modelMatrix);
+      gl.uniformMatrix4fv(this.u_normalMatrix, false, this._identity);
+      gl.uniform4f(this.u_color, inst.color[0], inst.color[1], inst.color[2], inst.color[3]);
+      gl.drawArrays(gl.TRIANGLES, 0, this.vertexCount);
+    }
+
+    gl.bindVertexArray(null);
+  }
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load image ${url}`));
+    img.src = url;
+  });
+}

--- a/src/viewWebGL2/textureSamplingGLSL.ts
+++ b/src/viewWebGL2/textureSamplingGLSL.ts
@@ -1,0 +1,42 @@
+import { getBlockTextureConfig } from '../webgpu/blockTexture.js';
+
+/** GLSL body for subregion UV transform matching textureSampling.ts */
+export function getSubregionUVTransformGLSL(): string {
+  const config = getBlockTextureConfig();
+  const sx = config.subregionX ?? 0;
+  const sy = config.subregionY ?? 0;
+  const sw = config.subregionWidth ?? 1;
+  const sh = config.subregionHeight ?? 1;
+  const inset = config.subregionInset ?? 0;
+
+  if (config.samplingMode === 'single') {
+    return `
+vec2 transformUVForSampling(vec2 uv) {
+  return clamp(vec2(uv.x, 1.0 - uv.y), 0.0, 1.0);
+}`;
+  }
+
+  if (config.samplingMode === 'atlas') {
+    const cols = config.atlasColumns ?? 4;
+    const rows = config.atlasRows ?? 3;
+    const tileCol = config.atlasTileColumn ?? 1;
+    const tileRow = config.atlasTileRow ?? 1;
+    const atlasInset = config.atlasTileInset ?? 0.03;
+    return `
+vec2 transformUVForSampling(vec2 uv) {
+  vec2 texUV = clamp(vec2(uv.x, 1.0 - uv.y), 0.0, 1.0);
+  vec2 atlasTiles = vec2(${cols}.0, ${rows}.0);
+  vec2 atlasTile = vec2(${tileCol}.0, ${tileRow}.0);
+  vec2 atlasInset = vec2(${atlasInset}, ${atlasInset});
+  return (texUV * (vec2(1.0) - atlasInset * 2.0) + atlasInset + atlasTile) / atlasTiles;
+}`;
+  }
+
+  return `
+vec2 transformUVForSampling(vec2 uv) {
+  vec2 texUV = clamp(vec2(uv.x, 1.0 - uv.y), 0.0, 1.0);
+  float inset = ${inset};
+  vec2 innerUV = texUV * (1.0 - inset * 2.0) + inset;
+  return vec2(${sx} + innerUV.x * ${sw}, ${sy} + innerUV.y * ${sh});
+}`;
+}

--- a/src/viewWebGL2/viewWebGL2.ts
+++ b/src/viewWebGL2/viewWebGL2.ts
@@ -1,0 +1,358 @@
+import * as Matrix from 'gl-matrix';
+import type { IView } from '../view/IView.js';
+import { buildPlayfieldInstances } from '../view/playfieldInstances.js';
+import { GLBlockRenderer } from './glBlockRenderer.js';
+import { themes, Themes } from '../webgpu/themes.js';
+import { MaterialThemes } from '../webgpu/materials.js';
+import {
+  BOARD_WORLD_CENTER_X,
+  BOARD_WORLD_CENTER_Y,
+} from '../webgpu/renderMetrics.js';
+import { VisualEffects } from '../webgpu/effects.js';
+import { ReactiveVideoBackground } from '../webgpu/reactiveVideo.js';
+import {
+  renderEndScreen as handleRenderEndScreen,
+  renderMainScreen as handleRenderMainScreen,
+  renderPauseScreen as handleRenderPauseScreen,
+  showFloatingText as handleShowFloatingText,
+  onHardDrop as handleHardDrop,
+  onHold as handleHold,
+  onLineClear as handleLineClear,
+  onLock as handleLock,
+  onMove as handleMove,
+  onRotate as handleRotate,
+} from '../webgpu/viewGameEvents.js';
+import { renderPiece as renderPieceImpl } from '../webgpu/viewMaterials.js';
+import { renderLogger } from '../utils/logger.js';
+
+const glMatrix = Matrix;
+
+const noopParticleSystem = {
+  emitParticles: () => {},
+  emitParticlesRadial: () => {},
+  emitLineClearShards: () => {},
+  maxParticles: 0,
+};
+
+function getMaterialTypeIndex(name: string): number {
+  switch (name) {
+    case 'Gold': return 1;
+    case 'Chrome': return 2;
+    case 'Glass': return 3;
+    default: return 0;
+  }
+}
+
+export default class ViewWebGL2 implements IView {
+  readonly rendererName = 'webgl2' as const;
+
+  element: HTMLElement;
+  width: number;
+  height: number;
+  nextPieceContext: CanvasRenderingContext2D;
+  holdPieceContext: CanvasRenderingContext2D;
+  canvasWebGPU: HTMLCanvasElement;
+  currentTheme: any = themes.premium;
+  materialThemeName = 'premium';
+  state: any;
+  visualEffects: VisualEffects;
+  reactiveVideoBackground: ReactiveVideoBackground;
+  particleSystem = noopParticleSystem;
+
+  useGlitch = false;
+  useReactiveVideo = true;
+  useReactiveMusic = false;
+  bloomEnabled = false;
+  useWireframe = false;
+  authoredBlockTextureLoaded = false;
+  lastEffectCounter = -1;
+  lastScore = -1;
+
+  private gl!: WebGL2RenderingContext;
+  private blockRenderer!: GLBlockRenderer;
+  private ready = false;
+  private startTime = performance.now();
+
+  private visualX = 0;
+  private visualY = 0;
+  private _previousActivePiece: any = null;
+  private _shakeOffsetSmoothed = { x: 0, y: 0 };
+
+  private VIEWMATRIX = glMatrix.mat4.create();
+  private PROJMATRIX = glMatrix.mat4.create();
+  private vpMatrix = glMatrix.mat4.create();
+  private _camEye = glMatrix.vec3.fromValues(0, BOARD_WORLD_CENTER_Y + 2, 75);
+  private _camTarget = glMatrix.vec3.fromValues(BOARD_WORLD_CENTER_X, BOARD_WORLD_CENTER_Y, 0);
+  private _camUp = glMatrix.vec3.fromValues(0, 1, 0);
+  private _lightPos = glMatrix.vec3.fromValues(12, 18, 28);
+
+  private themes = themes;
+
+  constructor(
+    element: HTMLElement,
+    width: number,
+    height: number,
+    _rows: number,
+    _cols: number,
+    nextPieceContext: CanvasRenderingContext2D,
+    holdPieceContext: CanvasRenderingContext2D,
+  ) {
+    this.element = element;
+    this.width = width;
+    this.height = height;
+    this.nextPieceContext = nextPieceContext;
+    this.holdPieceContext = holdPieceContext;
+
+    this.visualEffects = new VisualEffects(element, width, height);
+    this.reactiveVideoBackground = new ReactiveVideoBackground(element, width, height);
+
+    this.canvasWebGPU = document.createElement('canvas');
+    this.canvasWebGPU.id = 'canvaswebgpu';
+    this.canvasWebGPU.style.position = 'absolute';
+    this.canvasWebGPU.style.top = '0';
+    this.canvasWebGPU.style.left = '0';
+    this.canvasWebGPU.style.zIndex = '2';
+    this.canvasWebGPU.style.pointerEvents = 'none';
+    this.canvasWebGPU.width = width;
+    this.canvasWebGPU.height = height;
+
+    this.state = {
+      playfield: Array(20).fill(null).map(() => Array(10).fill(0)),
+      lockTimer: 0,
+      lockDelayTime: 500,
+    };
+
+    this.element.appendChild(this.canvasWebGPU);
+    window.addEventListener('resize', this.resize.bind(this));
+  }
+
+  static async create(
+    element: HTMLElement,
+    width: number,
+    height: number,
+    rows: number,
+    cols: number,
+    nextPieceContext: CanvasRenderingContext2D,
+    holdPieceContext: CanvasRenderingContext2D,
+  ): Promise<ViewWebGL2> {
+    const view = new ViewWebGL2(element, width, height, rows, cols, nextPieceContext, holdPieceContext);
+    await view.init();
+    return view;
+  }
+
+  private async init(): Promise<void> {
+    const gl = this.canvasWebGPU.getContext('webgl2', {
+      alpha: true,
+      premultipliedAlpha: true,
+      antialias: true,
+    });
+    if (!gl) {
+      throw new Error('WebGL2 is not available in this browser.');
+    }
+    this.gl = gl;
+    this.blockRenderer = new GLBlockRenderer(gl);
+    this.authoredBlockTextureLoaded = await this.blockRenderer.init(import.meta.url);
+    this.updateProjection();
+    this.ready = true;
+    this.showRendererBadge();
+    renderLogger.info('WebGL2 fallback renderer initialized');
+  }
+
+  private showRendererBadge(): void {
+    const badge = document.createElement('div');
+    badge.id = 'renderer-badge';
+    badge.textContent = 'WebGL2';
+    badge.style.cssText =
+      'position:fixed;bottom:8px;right:8px;z-index:9999;padding:4px 8px;' +
+      'font:12px monospace;background:rgba(0,0,0,0.55);color:#8cf;border-radius:4px;pointer-events:none;';
+    document.body.appendChild(badge);
+  }
+
+  resize(): void {
+    const dpr = window.devicePixelRatio || 1;
+    this.width = window.innerWidth;
+    this.height = window.innerHeight;
+    this.canvasWebGPU.width = Math.floor(this.width * dpr);
+    this.canvasWebGPU.height = Math.floor(this.height * dpr);
+    this.canvasWebGPU.style.width = `${this.width}px`;
+    this.canvasWebGPU.style.height = `${this.height}px`;
+    this.visualEffects.updateVideoPosition(this.width, this.height);
+    this.updateProjection();
+  }
+
+  private updateProjection(): void {
+    if (!this.gl) return;
+    this.gl.viewport(0, 0, this.canvasWebGPU.width, this.canvasWebGPU.height);
+    glMatrix.mat4.perspective(
+      this.PROJMATRIX,
+      (42 * Math.PI) / 180,
+      this.canvasWebGPU.width / this.canvasWebGPU.height,
+      1,
+      150,
+    );
+  }
+
+  setTheme(themeName: keyof Themes): void {
+    this.currentTheme = this.themes[themeName];
+    this.visualEffects.currentLevel = 0;
+    if (this.useReactiveVideo && this.currentTheme.levelVideos) {
+      this.reactiveVideoBackground.setVideoSources(this.currentTheme.levelVideos);
+      this.reactiveVideoBackground.updateForLevel(0, true);
+    }
+    this.setMaterialTheme(themeName);
+  }
+
+  setMaterialTheme(themeName: string, _pieceType = 1): void {
+    const visualTheme = this.themes[themeName as keyof Themes];
+    if (visualTheme) {
+      this.currentTheme = visualTheme;
+      this.materialThemeName = visualTheme.materialTheme || 'classic';
+    } else if (themeName in MaterialThemes) {
+      this.materialThemeName = themeName;
+    }
+    renderLogger.info(`[WebGL2] theme=${themeName} material=${this.materialThemeName}`);
+  }
+
+  setPremiumVisualsPreset(options: Record<string, unknown> = {}): void {
+    if (typeof options.reactiveVideo === 'boolean') {
+      this.useReactiveVideo = options.reactiveVideo;
+      if (this.useReactiveVideo && this.currentTheme?.levelVideos) {
+        this.reactiveVideoBackground.setVideoSources(this.currentTheme.levelVideos);
+        this.reactiveVideoBackground.updateForLevel(this.state?.level ?? 0, true);
+      }
+    }
+  }
+
+  initReactiveMusic(): void {
+    this.useReactiveMusic = false;
+  }
+
+  toggleGlitch(): void {
+    this.useGlitch = !this.useGlitch;
+  }
+
+  toggleBloom(): void {
+    this.bloomEnabled = !this.bloomEnabled;
+  }
+
+  setWireframe(_enabled: boolean): void {}
+
+  renderPiece(ctx: CanvasRenderingContext2D, piece: any, blockSize = 20): void {
+    renderPieceImpl(ctx, piece, this.currentTheme, blockSize);
+  }
+
+  showFloatingText(text: string, subText = ''): void {
+    handleShowFloatingText(this, text, subText);
+  }
+
+  renderMainScreen(state: any): void {
+    handleRenderMainScreen(this, state);
+  }
+
+  /** No-op for WebGL2 — playfield instances are built during render(). */
+  renderPlayfield_WebGPU(_state: any): void {}
+
+  renderEndScreen(state: any): void {
+    handleRenderEndScreen(this, state);
+  }
+
+  renderPauseScreen(): void {
+    handleRenderPauseScreen(this);
+  }
+
+  onLineClear(lines: number[], tSpin = false, combo = 0, backToBack = false, isAllClear = false): void {
+    handleLineClear(this, lines, tSpin, combo, backToBack, isAllClear);
+  }
+
+  onLock(isTSpin = false): void {
+    handleLock(this, isTSpin);
+  }
+
+  onHardDrop(x: number, ghostY: number, dropDist: number, colorIdx: number): void {
+    handleHardDrop(this, x, ghostY, dropDist, colorIdx);
+  }
+
+  onMove(x: number, y: number): void {
+    handleMove(this, x, y);
+  }
+
+  onRotate(): void {
+    handleRotate(this);
+  }
+
+  onHold(): void {
+    handleHold(this);
+  }
+
+  triggerNeonBloomFlashEffects(_intensity: number): void {}
+
+  render(dt: number): void {
+    if (!this.ready || !this.gl) return;
+
+    const clampedDt = Math.min(dt, 0.1);
+    this.updatePieceInterpolation(clampedDt);
+    this.visualEffects.updateEffects(clampedDt);
+
+    const time = (performance.now() - this.startTime) / 1000;
+    this.updateCamera(clampedDt, time);
+
+    const gl = this.gl;
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    const instances = buildPlayfieldInstances(
+      this.state,
+      this.currentTheme,
+      this.visualX,
+      this.visualY,
+    );
+
+    const material = MaterialThemes[this.materialThemeName]?.[1] ?? MaterialThemes.classic[1];
+    const textureMix = this.authoredBlockTextureLoaded ? 0.94 : 0.55;
+
+    this.blockRenderer.draw(
+      this.vpMatrix,
+      [this._camEye[0], this._camEye[1], this._camEye[2]],
+      [this._lightPos[0], this._lightPos[1], this._lightPos[2]],
+      textureMix,
+      getMaterialTypeIndex(material.name),
+      instances,
+    );
+  }
+
+  private updatePieceInterpolation(clampedDt: number): void {
+    if (this.state?.activePiece) {
+      const targetX = this.state.activePiece.x;
+      const targetY = this.state.activePiece.y;
+      if (this._previousActivePiece !== this.state.activePiece) {
+        this.visualX = targetX;
+        this.visualY = targetY;
+        this._previousActivePiece = this.state.activePiece;
+      } else {
+        const expDecay = 1.0 / (1.0 + clampedDt * 25.0);
+        this.visualX = targetX + (this.visualX - targetX) * expDecay;
+        this.visualY = targetY + (this.visualY - targetY) * expDecay;
+      }
+    } else {
+      this._previousActivePiece = null;
+    }
+  }
+
+  private updateCamera(clampedDt: number, time: number): void {
+    let camX = Math.sin(time * 0.2) * 0.5;
+    let camY = BOARD_WORLD_CENTER_Y + Math.cos(time * 0.3) * 0.25 + 2.0;
+    const shake = this.visualEffects.getShakeOffset();
+    const shakeDecay = 1.0 / (1.0 + clampedDt * 10.0);
+    this._shakeOffsetSmoothed.x = shake.x + (this._shakeOffsetSmoothed.x - shake.x) * shakeDecay;
+    this._shakeOffsetSmoothed.y = shake.y + (this._shakeOffsetSmoothed.y - shake.y) * shakeDecay;
+    camX += this._shakeOffsetSmoothed.x;
+    camY += this._shakeOffsetSmoothed.y;
+
+    this._camEye[0] = camX;
+    this._camEye[1] = camY;
+    this._camEye[2] = 75;
+
+    glMatrix.mat4.lookAt(this.VIEWMATRIX, this._camEye, this._camTarget, this._camUp);
+    glMatrix.mat4.multiply(this.vpMatrix, this.PROJMATRIX, this.VIEWMATRIX);
+  }
+}

--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -92,6 +92,7 @@ import { executeRenderLoop } from './webgpu/viewRenderLoop.js';
 const glMatrix = Matrix;
 
 export default class View {
+  readonly rendererName = 'webgpu' as const;
   element: HTMLElement;
   width: number;
   height: number;

--- a/tests/playfield-instances.test.ts
+++ b/tests/playfield-instances.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlayfieldInstances } from '../src/view/playfieldInstances.js';
+import { themes } from '../src/webgpu/themes.js';
+
+describe('buildPlayfieldInstances', () => {
+  it('creates one instance per occupied cell', () => {
+    const playfield = Array(20).fill(null).map(() => Array(10).fill(0));
+    playfield[5][3] = 2;
+    playfield[5][4] = 2;
+    const instances = buildPlayfieldInstances(
+      { playfield, activePiece: null },
+      themes.neon,
+      0,
+      0,
+    );
+    expect(instances).toHaveLength(2);
+    expect(instances[0].color[3]).toBeCloseTo(0.9);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **WebGL2 fallback rendering mode** alongside the existing WebGPU path. This gives us:

1. A simpler GLSL pipeline to iterate on `block.png` gold/glass image sampling
2. **Reliable headless screenshots** (WebGPU does not render in Playwright headless Chrome)
3. Automatic fallback when `navigator.gpu` is unavailable

## Usage

| URL / setting | Behavior |
|---|---|
| Default (`auto`) | WebGPU if available, else WebGL2 |
| `?renderer=webgl2` | Force WebGL2 (shows **WebGL2** badge bottom-right) |
| `?renderer=webgpu` | Force WebGPU |
| `localStorage.tetris_renderer` | Persist `webgl2` or `webgpu` preference |

## Architecture

- `src/view/IView.ts` — shared interface for Controller/index.ts
- `src/view/createView.ts` — capability detection + factory
- `src/viewWebGL2/` — WebGL2 backend (textured cubes, geometric gold/glass mask, theme-aware alpha)
- `src/view/playfieldInstances.ts` — shared CPU block instance builder

WebGL2 path reuses: themes, `block.png` subregion config, reactive video background, DOM visual effects. Skips post-process, particles, bloom (v1).

## Screenshots

Captured with `node scripts/capture-screenshot.mjs` using `?renderer=webgl2`:

- Image Sampled: gold frames + piece-tinted glass, video visible through centers
- Gold: heavier opaque gold look

## Testing

- `npm test` — 58 tests pass
- `npm run build:all` — production build OK
- Manual: `npx vite preview` → open `/tetris-webgpu/?renderer=webgl2`

Builds on the image-sampling opacity fixes from #334.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed8b4b1-6d46-4e0b-bfae-aed4d02446f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed8b4b1-6d46-4e0b-bfae-aed4d02446f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple graphics renderers (WebGPU and WebGL2) with automatic fallback capability
  * Added renderer selection preferences that can be set via URL parameter or saved locally

* **Chores**
  * Refactored renderer architecture to support flexible graphics backend implementations
  * Added logging of renderer initialization details for debugging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->