### PR TITLE
Extract 2× block.png tile for sharper gold/glass texture sampling

### DIFF
--- a/src/viewWebGL2/blockShadersGLSL.ts
+++ b/src/viewWebGL2/blockShadersGLSL.ts
@@ -1,8 +1,10 @@
-import { getSubregionUVTransformGLSL } from './textureSamplingGLSL.js';
+/**
+ * WebGL2 block shaders — samples a 2× extracted block.png tile at mip 0.
+ * Gold frame + stained glass colours come from the texture (warmth mask)
+ * blended with a geometric UV frame for stable edges.
+ */
 
 export function createBlockShaderSources(): { vertex: string; fragment: string } {
-  const uvTransform = getSubregionUVTransformGLSL();
-
   const vertex = `#version 300 es
 precision highp float;
 
@@ -39,13 +41,22 @@ in vec3 vWorldPos;
 
 uniform vec3 u_lightPos;
 uniform vec3 u_eyePos;
-uniform float u_textureMix;
 uniform int u_materialType;
 uniform sampler2D u_blockTexture;
 
 out vec4 outColor;
 
-${uvTransform}
+vec2 transformUVForSampling(vec2 uv) {
+  return clamp(vec2(uv.x, 1.0 - uv.y), 0.0, 1.0);
+}
+
+float extractTextureMetalMask(vec3 rgb) {
+  float luma = dot(rgb, vec3(0.299, 0.587, 0.114));
+  float warmth = rgb.r - rgb.b;
+  float lumaBand = smoothstep(0.25, 0.55, luma) * (1.0 - smoothstep(0.82, 0.95, luma));
+  float warmthSignal = smoothstep(0.05, 0.20, warmth);
+  return clamp(lumaBand * warmthSignal * 3.0, 0.0, 1.0);
+}
 
 void main() {
   vec3 N = normalize(vNormal);
@@ -63,26 +74,38 @@ void main() {
   float distY = min(vUV.y, 1.0 - vUV.y);
   float distEdge = min(distX, distY);
   float borderThickness = 0.15;
-  float glassMask = smoothstep(borderThickness - 0.02, borderThickness, distEdge);
+  float glassMaskGeo = smoothstep(borderThickness - 0.02, borderThickness, distEdge);
 
-  vec3 frameColor = texColor.rgb * 1.2;
-  vec3 windowColor = texColor.rgb * (vColor.rgb * 1.25 + vec3(0.18));
-  vec3 authoredBase = mix(frameColor, windowColor, glassMask);
-  vec3 baseColor = mix(vColor.rgb, authoredBase, clamp(u_textureMix, 0.0, 1.0));
+  float textureMetal = extractTextureMetalMask(texColor.rgb);
+  float metalMask = clamp(max(1.0 - glassMaskGeo, textureMetal * 0.92), 0.0, 1.0);
+  float glassMask = 1.0 - metalMask;
 
-  float lightFactor = 0.38 + NdotL * 0.62;
+  float luma = dot(texColor.rgb, vec3(0.299, 0.587, 0.114));
+  float crystalBright = smoothstep(0.15, 0.90, luma);
+  float crystalHi = max(luma - 0.65, 0.0) * 2.5;
+
+  vec3 metalColor = texColor.rgb * 1.38 + vec3(0.04, 0.018, 0.0);
+  vec3 glassColor = texColor.rgb * (0.70 + crystalBright * 0.30)
+                  + vColor.rgb * 0.22 * crystalBright
+                  + vec3(crystalHi * 0.40);
+  vec3 baseColor = mix(glassColor, metalColor, metalMask);
+
+  float lightFactor = 0.42 + NdotL * 0.58;
   float nh2 = NdotH * NdotH;
   float nh4 = nh2 * nh2;
   float nh16 = nh4 * nh4;
   float tightSpec = nh16 * nh16 * nh16 * nh16;
-  float metalMask = 1.0 - glassMask;
-  float specularStrength = mix(0.04, 0.18, metalMask);
+  float specularStrength = mix(0.06, 0.22, metalMask);
   vec3 finalColor = baseColor * lightFactor + vec3(tightSpec * specularStrength);
 
-  if (glassMask > 0.2) {
-    float diffCenter = length(vUV - vec2(0.5));
-    float centerGlow = clamp((0.2025 - diffCenter * diffCenter) / 0.1225, 0.0, 1.0);
-    finalColor += vColor.rgb * 0.06 * centerGlow * glassMask;
+  if (glassMask > 0.15) {
+    float iridescence = sin(NdotV * 7.0) * 0.5 + 0.5;
+    vec3 rainbow = vec3(
+      sin(iridescence * 6.28) * 0.5 + 0.5,
+      sin(iridescence * 6.28 + 2.09) * 0.5 + 0.5,
+      sin(iridescence * 6.28 + 4.18) * 0.5 + 0.5
+    );
+    finalColor += rainbow * tightSpec * 0.12 * glassMask;
   }
 
   float edgeFresnel = 1.0 - NdotV;

--- a/src/viewWebGL2/glBlockRenderer.ts
+++ b/src/viewWebGL2/glBlockRenderer.ts
@@ -1,5 +1,10 @@
 import { CubeData } from '../webgpu/geometry.js';
 import { resolveBlockTextureUrl } from '../webgpu/blockTexture.js';
+import {
+  BLOCK_TILE_EXTRACT_SCALE,
+  extractBlockTileFromImage,
+  loadBlockTextureImage,
+} from '../webgpu/blockTextureExtract.js';
 import { createBlockShaderSources } from './blockShadersGLSL.js';
 import { textureLogger } from '../utils/logger.js';
 
@@ -48,8 +53,9 @@ export class GLBlockRenderer {
   private u_color!: WebGLUniformLocation;
   private u_lightPos!: WebGLUniformLocation;
   private u_eyePos!: WebGLUniformLocation;
-  private u_textureMix!: WebGLUniformLocation;
   private u_materialType!: WebGLUniformLocation;
+  private tileWidth = 0;
+  private tileHeight = 0;
 
   private _identity = new Float32Array([
     1, 0, 0, 0,
@@ -73,7 +79,6 @@ export class GLBlockRenderer {
     this.u_color = gl.getUniformLocation(this.program, 'u_color')!;
     this.u_lightPos = gl.getUniformLocation(this.program, 'u_lightPos')!;
     this.u_eyePos = gl.getUniformLocation(this.program, 'u_eyePos')!;
-    this.u_textureMix = gl.getUniformLocation(this.program, 'u_textureMix')!;
     this.u_materialType = gl.getUniformLocation(this.program, 'u_materialType')!;
 
     const cube = CubeData();
@@ -108,19 +113,29 @@ export class GLBlockRenderer {
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
     try {
       const url = resolveBlockTextureUrl(moduleUrl);
       textureLogger.info('[WebGL2] Loading block texture from:', url);
-      const image = await loadImage(url);
+      const image = await loadBlockTextureImage(url);
+      const extracted = extractBlockTileFromImage(image, BLOCK_TILE_EXTRACT_SCALE);
+      this.tileWidth = extracted.width;
+      this.tileHeight = extracted.height;
+
       gl.bindTexture(gl.TEXTURE_2D, this.texture);
       gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-      gl.generateMipmap(gl.TEXTURE_2D);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, extracted.canvas);
+      // Mip 0 only — preserve 2× extracted gold/glass detail from block.png
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
       this.authoredTextureLoaded = true;
-      textureLogger.info('[WebGL2] Block texture loaded:', image.width, 'x', image.height);
+      textureLogger.info(
+        '[WebGL2] Block tile extracted:',
+        `${Math.round(extracted.sourceWidth)}×${Math.round(extracted.sourceHeight)}`,
+        '→',
+        `${extracted.width}×${extracted.height}`,
+        `(${extracted.scale}×)`,
+      );
     } catch (e) {
       textureLogger.error('[WebGL2] Block texture load failed:', e);
       gl.bindTexture(gl.TEXTURE_2D, this.texture);
@@ -145,7 +160,7 @@ export class GLBlockRenderer {
     viewProjection: Float32Array,
     eyePos: [number, number, number],
     lightPos: [number, number, number],
-    textureMix: number,
+    _textureMix: number,
     materialType: number,
     instances: Array<{ modelMatrix: Float32Array; color: [number, number, number, number] }>,
   ): void {
@@ -158,7 +173,6 @@ export class GLBlockRenderer {
     gl.uniformMatrix4fv(this.u_viewProjection, false, viewProjection);
     gl.uniform3f(this.u_lightPos, lightPos[0], lightPos[1], lightPos[2]);
     gl.uniform3f(this.u_eyePos, eyePos[0], eyePos[1], eyePos[2]);
-    gl.uniform1f(this.u_textureMix, textureMix);
     gl.uniform1i(this.u_materialType, materialType);
 
     for (const inst of instances) {
@@ -170,14 +184,7 @@ export class GLBlockRenderer {
 
     gl.bindVertexArray(null);
   }
-}
-
-function loadImage(url: string): Promise<HTMLImageElement> {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.crossOrigin = 'anonymous';
-    img.onload = () => resolve(img);
-    img.onerror = () => reject(new Error(`Failed to load image ${url}`));
-    img.src = url;
-  });
+  get tileSize(): { width: number; height: number } {
+    return { width: this.tileWidth, height: this.tileHeight };
+  }
 }

--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -49,7 +49,12 @@ import {
   resolveBlockTextureUrl,
   getTextureMipLevelCount,
   createBlockTextureSamplerDescriptor,
+  setBlockTextureConfig,
 } from './webgpu/blockTexture.js';
+import {
+  BLOCK_TILE_EXTRACT_SCALE,
+  extractBlockTileFromImage,
+} from './webgpu/blockTextureExtract.js';
 import { UNIFORM_BUFFER_SIZES } from './config/renderConfig.js';
 import { renderLogger, textureLogger, shaderLogger } from './utils/logger.js';
 import {
@@ -560,8 +565,10 @@ export default class View {
           };
         });
 
-        // Preserve the authored texture data for direct WebGPU upload without browser-side premultiplication or color transforms.
-        const imageBitmap = await createImageBitmap(img, {
+        const extracted = extractBlockTileFromImage(img, BLOCK_TILE_EXTRACT_SCALE);
+        setBlockTextureConfig({ samplingMode: 'single' });
+
+        const imageBitmap = await createImageBitmap(extracted.canvas, {
           premultiplyAlpha: 'none',
           colorSpaceConversion: 'none',
         });
@@ -574,7 +581,12 @@ export default class View {
         this.device.queue.copyExternalImageToTexture({ source: imageBitmap }, { texture: this.blockTexture }, [imageBitmap.width, imageBitmap.height]);
         generateMipmapsUtil(this.device, this.blockTexture, imageBitmap.width, imageBitmap.height, this.blockTexture.mipLevelCount);
         this.authoredBlockTextureLoaded = true;
-        textureLogger.info('Loaded successfully:', imageBitmap.width, 'x', imageBitmap.height, 'with', this.blockTexture.mipLevelCount, 'mips');
+        textureLogger.info(
+          'Loaded extracted tile:',
+          Math.round(extracted.sourceWidth), 'x', Math.round(extracted.sourceHeight),
+          '→', imageBitmap.width, 'x', imageBitmap.height,
+          `(${extracted.scale}×) with`, this.blockTexture.mipLevelCount, 'mips',
+        );
     } catch (e) {
         this.authoredBlockTextureLoaded = false;
         textureLogger.error('Failed to load block texture:', e);

--- a/src/webgpu/blockTextureExtract.ts
+++ b/src/webgpu/blockTextureExtract.ts
@@ -1,0 +1,104 @@
+import {
+  getBlockTextureConfig,
+  type BlockTextureConfig,
+} from './blockTexture.js';
+
+/** Upscale factor when baking the atlas tile into a dedicated block texture. */
+export const BLOCK_TILE_EXTRACT_SCALE = 2.0;
+
+export interface ExtractedBlockTile {
+  canvas: HTMLCanvasElement;
+  width: number;
+  height: number;
+  sourceWidth: number;
+  sourceHeight: number;
+  scale: number;
+}
+
+/**
+ * Crop the authored middle block tile from the full block.png atlas and upscale it.
+ * Default 2× turns the ~696×685 source crop into ~1392×1370 for sharper face sampling.
+ */
+export function extractBlockTileFromImage(
+  image: CanvasImageSource & { width: number; height: number },
+  scale = BLOCK_TILE_EXTRACT_SCALE,
+  config: BlockTextureConfig = getBlockTextureConfig(),
+): ExtractedBlockTile {
+  const imgW = image.width;
+  const imgH = image.height;
+
+  const sx = (config.subregionX ?? 0) * imgW;
+  const sy = (config.subregionY ?? 0) * imgH;
+  const sw = (config.subregionWidth ?? 1) * imgW;
+  const sh = (config.subregionHeight ?? 1) * imgH;
+  const inset = config.subregionInset ?? 0;
+
+  const cropX = sx + sw * inset;
+  const cropY = sy + sh * inset;
+  const cropW = sw * (1.0 - inset * 2.0);
+  const cropH = sh * (1.0 - inset * 2.0);
+
+  const outW = Math.max(1, Math.round(cropW * scale));
+  const outH = Math.max(1, Math.round(cropH * scale));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = outW;
+  canvas.height = outH;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Unable to create 2D context for block tile extraction');
+  }
+
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(image, cropX, cropY, cropW, cropH, 0, 0, outW, outH);
+
+  return {
+    canvas,
+    width: outW,
+    height: outH,
+    sourceWidth: cropW,
+    sourceHeight: cropH,
+    scale,
+  };
+}
+
+export function loadBlockTextureImage(url: string, timeoutMs = 10000): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    let timeoutId = 0;
+
+    const cleanup = () => {
+      window.clearTimeout(timeoutId);
+      img.onload = null;
+      img.onerror = null;
+    };
+
+    timeoutId = window.setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out loading ${url} after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    img.onload = () => {
+      cleanup();
+      resolve(img);
+    };
+    img.onerror = () => {
+      cleanup();
+      reject(new Error(`Failed to load ${url}`));
+    };
+
+    img.src = url;
+  });
+}
+
+export async function extractBlockTileFromUrl(
+  url: string,
+  scale = BLOCK_TILE_EXTRACT_SCALE,
+  config?: BlockTextureConfig,
+): Promise<ExtractedBlockTile> {
+  const image = await loadBlockTextureImage(url);
+  return extractBlockTileFromImage(image, scale, config);
+}

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -228,9 +228,9 @@ export const PBRBlockShaders = () => {
             let effectiveTextureMix = max(textureMix, select(0.0, 0.94, isBorderBlock));
             let useAuthoredSampling = effectiveTextureMix > 0.45;
 
-            // Blend geometric frame with texture gold detection for visible hinges + stable edges.
+            // Blend geometric frame with texture warmth (gold hinges read from block.png pixels).
             let combinedMetalMask = clamp(
-                metalMaskGeo + textureMetalMask * (1.0 - metalMaskGeo) * 0.65,
+                max(metalMaskGeo, textureMetalMask * 0.92),
                 0.0, 1.0
             );
             let combinedGlassMask = 1.0 - combinedMetalMask;
@@ -238,10 +238,14 @@ export const PBRBlockShaders = () => {
             let metalMask = select(textureMetalMask, combinedMetalMask, useAuthoredSampling);
             let glassMask = select(textureGlassMask, combinedGlassMask, useAuthoredSampling);
 
-            // Reference build: frame = pure texture gold, window = texture detail * piece tint.
-            let frameColor = texColor.rgb * 1.2;
-            let windowColor = texColor.rgb * (vColor.rgb * 1.25 + vec3f(0.18));
-            let authoredBase = mix(frameColor, windowColor, combinedGlassMask);
+            let luma = dot(texColor.rgb, vec3f(0.299, 0.587, 0.114));
+            let crystalBright = smoothstep(0.15, 0.90, luma);
+            let crystalHi = max(luma - 0.65, 0.0) * 2.5;
+            let metalColor = texColor.rgb * 1.38 + vec3f(0.04, 0.018, 0.0);
+            let glassColor = texColor.rgb * (0.70 + crystalBright * 0.30)
+                           + vColor.rgb * 0.22 * crystalBright
+                           + vec3f(crystalHi * 0.40);
+            let authoredBase = mix(glassColor, metalColor, combinedMetalMask);
             let textureBase = composeMaterialBaseColor(texColor.rgb, vColor.rgb, textureMetalMask);
 
             var baseColor: vec3f;

--- a/tests/block-texture-extract.test.ts
+++ b/tests/block-texture-extract.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { BLOCK_TILE_EXTRACT_SCALE } from '../src/webgpu/blockTextureExtract.js';
+import { DEFAULT_BLOCK_TEXTURE_CONFIG } from '../src/webgpu/blockTexture.js';
+
+describe('block texture extraction', () => {
+  it('defines 2× upscale for the middle atlas tile crop', () => {
+    expect(BLOCK_TILE_EXTRACT_SCALE).toBe(2);
+
+    const imgW = 2816;
+    const imgH = 1536;
+    const sw = (DEFAULT_BLOCK_TEXTURE_CONFIG.subregionWidth ?? 1) * imgW;
+    const sh = (DEFAULT_BLOCK_TEXTURE_CONFIG.subregionHeight ?? 1) * imgH;
+    const inset = DEFAULT_BLOCK_TEXTURE_CONFIG.subregionInset ?? 0;
+
+    const cropW = sw * (1.0 - inset * 2.0);
+    const cropH = sh * (1.0 - inset * 2.0);
+
+    expect(Math.round(cropW * BLOCK_TILE_EXTRACT_SCALE)).toBe(1280);
+    expect(Math.round(cropH * BLOCK_TILE_EXTRACT_SCALE)).toBe(1261);
+  });
+});

--- a/tests/shader-optimizations.test.ts
+++ b/tests/shader-optimizations.test.ts
@@ -64,7 +64,7 @@ describe('shader optimization updates', () => {
     expect(fragment).toContain('composeMaterialBaseColor');
     expect(fragment).toContain('useAuthoredSampling');
     expect(fragment).toContain('borderThickness = 0.15');
-    expect(fragment).toContain('let frameColor = texColor.rgb * 1.2');
+    expect(fragment).toContain('let metalColor = texColor.rgb * 1.38');
     expect(fragment).toContain('let glassOpacity = mix(glassMin, glassMax');
     expect(fragment).toContain('combinedMetalMask');
     expect(fragment).toContain('isBorderBlock');


### PR DESCRIPTION
Rework image upload: crop the middle atlas tile from the full 2816×1536 block.png and upscale 2× (~1280×1261) into a dedicated GPU texture instead of subregion UV math on the full atlas at runtime.

- blockTextureExtract.ts: shared 2× tile bake utility
- WebGL2: upload extracted tile, mip-0 LINEAR, warmth+geometry masks
- WebGPU: same extraction before shader init, single-mode sampling
- Shader: texture-first gold/glass colors (metal 1.38×, crystal from luma)