### PR TITLE
fix: tune MAX_LOCK_RESETS to 15 for improved game feel

### DIFF
--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -22,7 +22,7 @@ export const LOCK_DELAY_CONFIG = {
   /** Standard lock delay time */
   LOCK_DELAY_MS: 500,
   /** Maximum number of lock delay resets (Infinity-like behavior) */
-  MAX_LOCK_RESETS: 25,
+  MAX_LOCK_RESETS: 15,
 } as const;
 
 // Playfield dimensions


### PR DESCRIPTION
Fix `MAX_LOCK_RESETS` to 15 in `src/config/gameConfig.ts` to tune the game feel according to the Infinity mechanics guidelines. This restricts extended placement from 25 to 15 resets to keep the gameplay generous but fair. I've also verified that all visual shader requests (Neon Bloom, Shockwaves, Fresnel Rim Lighting, Additive Blending) mentioned in the prompt are already active in the WebGPU codebase.

---
*PR created automatically by Jules for task [3217914384764484574](https://jules.google.com/task/3217914384764484574) started by @ford442*