### PR TITLE
Fix ghostly block transparency and remove non-image-sampled modes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -349,10 +349,11 @@ uiContainer.innerHTML = `
   window.controller = controller;
   window.soundManager = soundManager;
 
-  // Image-sampled blocks from block.png (gold frame + stained-glass crystal)
+  // Image-sampled blocks from block.png — clear any legacy theme/mode localStorage
+  localStorage.removeItem('tetris_theme_class');
+  localStorage.setItem('tetris_theme_class', 'image-sampled-theme');
+  localStorage.setItem('tetris_theme_name', 'imageSampled');
   document.body.className = 'image-sampled-theme';
   view.setTheme('imageSampled');
   view.setMaterialTheme?.('imageSampled', 1);
-  localStorage.setItem('tetris_theme_class', 'image-sampled-theme');
-  localStorage.setItem('tetris_theme_name', 'imageSampled');
 })();

--- a/src/view/playfieldInstances.ts
+++ b/src/view/playfieldInstances.ts
@@ -29,7 +29,7 @@ export function buildPlayfieldInstances(
       if (!value) continue;
 
       const colorIndex = Math.abs(value);
-      const alpha = value < 0 ? 0.3 : 0.9;
+      const alpha = value < 0 ? 0.35 : 1.0;
       const color = currentTheme[colorIndex] || currentTheme[0];
       const rgba: [number, number, number, number] = [color[0], color[1], color[2], alpha];
 

--- a/src/viewWebGL2/blockShadersGLSL.ts
+++ b/src/viewWebGL2/blockShadersGLSL.ts
@@ -110,19 +110,7 @@ void main() {
 
   float edgeFresnel = 1.0 - NdotV;
   float fresnelSq = edgeFresnel * edgeFresnel;
-  float glassMin = 0.38;
-  float glassMax = 0.78;
-  if (u_materialType == 1) {
-    glassMin = 0.72;
-    glassMax = 0.96;
-  } else if (u_materialType == 3) {
-    glassMin = 0.28;
-    glassMax = 0.68;
-  } else if (u_materialType == 2) {
-    glassMin = 0.68;
-    glassMax = 0.94;
-  }
-  float glassOpacity = mix(glassMin, glassMax, fresnelSq);
+  float glassOpacity = mix(0.82, 0.97, fresnelSq);
   float alpha = mix(1.0, glassOpacity, glassMask) * vColor.a;
 
   outColor = vec4(clamp(finalColor, 0.0, 1.0), alpha);

--- a/src/viewWebGL2/viewWebGL2.ts
+++ b/src/viewWebGL2/viewWebGL2.ts
@@ -3,7 +3,6 @@ import type { IView } from '../view/IView.js';
 import { buildPlayfieldInstances } from '../view/playfieldInstances.js';
 import { GLBlockRenderer } from './glBlockRenderer.js';
 import { themes, Themes } from '../webgpu/themes.js';
-import { MaterialThemes } from '../webgpu/materials.js';
 import {
   BOARD_WORLD_CENTER_X,
   BOARD_WORLD_CENTER_Y,
@@ -34,15 +33,6 @@ const noopParticleSystem = {
   maxParticles: 0,
 };
 
-function getMaterialTypeIndex(name: string): number {
-  switch (name) {
-    case 'Gold': return 1;
-    case 'Chrome': return 2;
-    case 'Glass': return 3;
-    default: return 0;
-  }
-}
-
 export default class ViewWebGL2 implements IView {
   readonly rendererName = 'webgl2' as const;
 
@@ -52,8 +42,7 @@ export default class ViewWebGL2 implements IView {
   nextPieceContext: CanvasRenderingContext2D;
   holdPieceContext: CanvasRenderingContext2D;
   canvasWebGPU: HTMLCanvasElement;
-  currentTheme: any = themes.premium;
-  materialThemeName = 'premium';
+  currentTheme: any = themes.imageSampled;
   state: any;
   visualEffects: VisualEffects;
   reactiveVideoBackground: ReactiveVideoBackground;
@@ -202,15 +191,9 @@ export default class ViewWebGL2 implements IView {
     this.setMaterialTheme(themeName);
   }
 
-  setMaterialTheme(themeName: string, _pieceType = 1): void {
-    const visualTheme = this.themes[themeName as keyof Themes];
-    if (visualTheme) {
-      this.currentTheme = visualTheme;
-      this.materialThemeName = visualTheme.materialTheme || 'classic';
-    } else if (themeName in MaterialThemes) {
-      this.materialThemeName = themeName;
-    }
-    renderLogger.info(`[WebGL2] theme=${themeName} material=${this.materialThemeName}`);
+  setMaterialTheme(_themeName?: string, _pieceType = 1): void {
+    this.currentTheme = themes.imageSampled;
+    renderLogger.info('[WebGL2] imageSampled material (block.png)');
   }
 
   setPremiumVisualsPreset(options: Record<string, unknown> = {}): void {
@@ -307,7 +290,6 @@ export default class ViewWebGL2 implements IView {
       this.visualY,
     );
 
-    const material = MaterialThemes[this.materialThemeName]?.[1] ?? MaterialThemes.classic[1];
     const textureMix = this.authoredBlockTextureLoaded ? 0.94 : 0.55;
 
     this.blockRenderer.draw(
@@ -315,7 +297,7 @@ export default class ViewWebGL2 implements IView {
       [this._camEye[0], this._camEye[1], this._camEye[2]],
       [this._lightPos[0], this._lightPos[1], this._lightPos[2]],
       textureMix,
-      getMaterialTypeIndex(material.name),
+      0,
       instances,
     );
   }

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -302,26 +302,10 @@ export const PBRBlockShaders = () => {
                     finalColor += vec3f(0.4, 0.65, 0.95) * edge3 * glassMask * 0.35;
                 }
 
-                // Opaque gold frame; glass window reveals the video portal underneath.
-                // Fresnel keeps edges solid; center stays translucent but readable.
+                // Opaque gold frame; stained-glass window stays readable over the video portal.
                 let edgeFresnel = 1.0 - NdotV;
                 let fresnelSq = edgeFresnel * edgeFresnel;
-                var glassMin: f32 = 0.38;
-                var glassMax: f32 = 0.78;
-                if (materialType == 1u) {
-                    // Gold — nearly solid blocks with a soft luminous center
-                    glassMin = 0.72;
-                    glassMax = 0.96;
-                } else if (materialType == 3u) {
-                    // Glass — most translucent so the portal reads clearly
-                    glassMin = 0.28;
-                    glassMax = 0.68;
-                } else if (materialType == 2u) {
-                    // Chrome — bright reflective panels
-                    glassMin = 0.68;
-                    glassMax = 0.94;
-                }
-                let glassOpacity = mix(glassMin, glassMax, fresnelSq);
+                let glassOpacity = mix(0.82, 0.97, fresnelSq);
                 finalAlpha = mix(1.0, glassOpacity, combinedGlassMask);
             } else if (fUniforms.enablePBR < 0.5 || materialType == 0u) {
                 // Classic mode

--- a/src/webgpu/viewPlayfield.ts
+++ b/src/webgpu/viewPlayfield.ts
@@ -65,7 +65,7 @@ export function renderPlayfieldBlocks(
 
       let value = playfield[row][colom];
       let colorBlockindex = Math.abs(value);
-      let alpha = value < 0 ? 0.3 : 0.9;
+      let alpha = value < 0 ? 0.35 : 1.0;
       let color = currentTheme[colorBlockindex] || currentTheme[0];
 
       _f32_4[0] = color[0]; _f32_4[1] = color[1]; _f32_4[2] = color[2]; _f32_4[3] = alpha;

--- a/tests/playfield-instances.test.ts
+++ b/tests/playfield-instances.test.ts
@@ -9,11 +9,11 @@ describe('buildPlayfieldInstances', () => {
     playfield[5][4] = 2;
     const instances = buildPlayfieldInstances(
       { playfield, activePiece: null },
-      themes.neon,
+      themes.imageSampled,
       0,
       0,
     );
     expect(instances).toHaveLength(2);
-    expect(instances[0].color[3]).toBeCloseTo(0.9);
+    expect(instances[0].color[3]).toBeCloseTo(1.0);
   });
 });

--- a/tests/shader-optimizations.test.ts
+++ b/tests/shader-optimizations.test.ts
@@ -65,7 +65,7 @@ it('composes gold frame and tinted glass using geometric UV frame mask', () => {
   expect(fragment).toContain('useAuthoredSampling');
   expect(fragment).toContain('borderThickness = 0.15');
   expect(fragment).toContain('let metalColor = texColor.rgb * 1.38');
-  expect(fragment).toContain('let glassOpacity = mix(glassMin, glassMax');
+    expect(fragment).toContain('let glassOpacity = mix(0.82, 0.97, fresnelSq)');
   expect(fragment).toContain('combinedMetalMask');
   expect(fragment).toContain('isBorderBlock');
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes blocks appearing washed-out/ghostly on test.1ink.us and removes unused block theme modes.

## Ghost transparency fix
- Raised stained-glass window opacity from **0.38–0.78** to **0.82–0.97** in WebGPU and WebGL2 block shaders
- Solid placed blocks now use vertex alpha **1.0** (was 0.9)
- The geometric frame mask makes ~85% of each face the glass window — the old 0.38 floor made entire blocks look like faint outlines

## Theme/mode cleanup
- Removed Pastel/Neon/Gold/Glass/Lava theme UI; always boots `imageSampled` from `block.png`
- WebGL2 fallback no longer references removed `themes.premium` / `MaterialThemes.classic`
- Clears legacy `tetris_theme_*` localStorage on boot

## Deployed
- Built and deployed to https://test.1ink.us/tetris-webgpu/

## Testing
- `npm test` — 62 tests passing
- `npm run build:all` — production build succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed8b4b1-6d46-4e0b-bfae-aed4d02446f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed8b4b1-6d46-4e0b-bfae-aed4d02446f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

