### PR TITLE
Add visual juice to block lock events and fix tests

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -31,4 +31,5 @@
 - "Implemented a massive 'Black Hole' gravitational lensing distortion and cyan event horizon glow in the post-processing pipeline, triggered on Tetris clears, causing the entire board to suck inward into a singularity!"
 - "Reduced MAX_LOCK_RESETS to 15 for tighter Infinity feel."
 - "Enhanced hard-drop shockwave distortion + aberration (WGSL) for juicy impact."
+- "Added subtle chromatic aberration on regular piece locks to ensure every placement feels tactile and weighty, not just hard drops."
 - "Conducted a full pass of the WebGPU rendering and game mechanics. Verified that the engine is fully 'juiced'. The shockwave distortion on Hard Drops, Fresnel Rim Lighting, Bloom, Chromatic Aberration, and Level-reactive background shaders are all active and performing beautifully. Game feel is perfectly tuned with DAS at 100ms and generous Infinity lock delay."

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -237,6 +237,8 @@ export function onLineClear(view: any, lines: number[], tSpin: boolean = false, 
 export function onLock(view: any, isTSpin: boolean = false): void {
   view.visualEffects.triggerLock(0.3);
   view.visualEffects.triggerShake(isTSpin ? 0.5 : 0.2, 0.15);
+  // JUICE: Chromatic Aberration on regular locks to make every placement tactile
+  view.visualEffects.triggerAberration(isTSpin ? 1.0 : 0.5);
 
   if (view.state?.activePiece) {
     const { x, y } = view.state.activePiece;

--- a/tests/playfield-instances.test.ts
+++ b/tests/playfield-instances.test.ts
@@ -9,7 +9,7 @@ describe('buildPlayfieldInstances', () => {
     playfield[5][4] = 2;
     const instances = buildPlayfieldInstances(
       { playfield, activePiece: null },
-      themes.neon,
+      themes.imageSampled,
       0,
       0,
     );


### PR DESCRIPTION
Added subtle chromatic aberration to regular piece locks in `viewGameEvents.ts` to make every placement feel tactile and weighty. Fixed a failing test `playfield-instances.test.ts` which used an obsolete theme name (`themes.neon` instead of `themes.imageSampled`). Updated the `neon_bricklayers_journal.md` with the new changes.

---
*PR created automatically by Jules for task [2397929783449783655](https://jules.google.com/task/2397929783449783655) started by @ford442*