### PR TITLE
Enhance particle explosion brightness for 'Neon Bricklayer' spec

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -33,3 +33,4 @@
 - "Enhanced hard-drop shockwave distortion + aberration (WGSL) for juicy impact."
 - "Added subtle chromatic aberration on regular piece locks to ensure every placement feels tactile and weighty, not just hard drops."
 - "Conducted a full pass of the WebGPU rendering and game mechanics. Verified that the engine is fully 'juiced'. The shockwave distortion on Hard Drops, Fresnel Rim Lighting, Bloom, Chromatic Aberration, and Level-reactive background shaders are all active and performing beautifully. Game feel is perfectly tuned with DAS at 100ms and generous Infinity lock delay."
+- "Boosted particle brightness in particle shader (8.0 base, 15.0 core) to make explosions feel even more incandescent and impactful."

--- a/src/webgpu/shaders/particle.ts
+++ b/src/webgpu/shaders/particle.ts
@@ -132,8 +132,8 @@ export const ParticleShaders = () => {
             if (hash > 0.92) { flicker *= 1.3; }
 
             // Brightness boost based on life phase
-            var brightness = 5.5;
-            if (lifeRatio > 0.8) { brightness = 12.0; }
+            var brightness = 8.0;
+            if (lifeRatio > 0.8) { brightness = 15.0; }
 
             return vec4<f32>(finalColor * brightness * lifeRatio, finalAlpha * pulse * flicker);
         }


### PR DESCRIPTION
In response to 'The Neon Bricklayer' identity prompt, this update adds an extra layer of 'JUICE' to the game's visuals. 
The WebGPU particle shader (`particle.ts`) was modified to significantly boost the brightness multiplier of particle explosions, making hard drops and line clears feel more incandescent and impactful. 
The `neon_bricklayers_journal.md` visual log was updated to reflect this game feel enhancement.

---
*PR created automatically by Jules for task [13459865524235202280](https://jules.google.com/task/13459865524235202280) started by @ford442*