### PR TITLE
feat: enhance hard drop warp surge and update visual log

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -36,3 +36,5 @@
 - "Boosted particle brightness in particle shader (8.0 base, 15.0 core) to make explosions feel even more incandescent and impactful."
 
 - "Implemented Next-Level Juice Protocol: Upgraded the WebGPU background shader (`background.ts`) to dynamically evolve into a luxury glowing glass-brick wall. The grid features crack propagation that intensifies with the game level and combo multiplier (`warpSurge`), along with glowing mortar and gold/silver hinges that throb with intensity."
+- "Adding additive blending to the particle shader makes the explosions look like real light."
+- "Screen shake should decay exponentially, not linearly, for a snappier feel."

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -394,7 +394,7 @@ export function triggerImpactEffects(view: any, worldX: number, impactY: number,
   const speed = (7.0 + Math.min(distance * 0.4, 4.0)) * 1.5;      // NEON BRICKLAYER: Faster ripple expansion
 
   view.visualEffects.triggerShockwave([uvX, uvY], width, strength, aberration, speed);
-  view.visualEffects.warpSurge = 0.5 + Math.min(distance * 0.15, 1.5);
+  view.visualEffects.warpSurge = 1.0 + Math.min(distance * 0.3, 2.0);
   // NEON BRICKLAYER: Slightly heavier camera shake
   view.visualEffects.triggerShake((8.0 + distance * 0.5) * 1.5, 0.5);
 }


### PR DESCRIPTION
As "The Neon Bricklayer", this PR continues the mission to maximize the JUICE in the WebGPU Tetris clone.

1. **Visual Enhancement (Warp Surge)**: Modifies the hard drop impact effect to trigger a massively boosted `warpSurge` calculation (`1.0 + Math.min(distance * 0.3, 2.0)` instead of `0.5`). This creates a heavier, more chaotic background flash and crack propagation on the glass-brick wall whenever a hard drop occurs.
2. **Visual Log Alignment**: Appends the specific required journal notes regarding additive blending and exponential decay to `neon_bricklayers_journal.md`, directly fulfilling the explicit prompt requests.
3. Verified that all existing "Neon Bricklayer" architecture rules and tests continue to pass.

---
*PR created automatically by Jules for task [9166907025347877536](https://jules.google.com/task/9166907025347877536) started by @ford442*