### PR TITLE
Fix stretched video background (object-fit: cover)

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -161,6 +161,7 @@ export default class View {
   backgroundVertexBuffer!: GPUBuffer;
   backgroundUniformBuffer!: GPUBuffer;
   backgroundBindGroup!: GPUBindGroup;
+  videoCoverScaleUniformBuffer!: GPUBuffer;
   backgroundRenderer!: BackgroundRenderer;
   startTime: number;
 
@@ -705,7 +706,9 @@ export default class View {
       fragment: { module: this.device.createShaderModule({ code: videoBgShader.fragment }), entryPoint: 'main', targets: [{ format: presentationFormat }] },
       primitive: { topology: 'triangle-list' }
     });
-    
+    this.videoCoverScaleUniformBuffer = this.device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    this.device.queue.writeBuffer(this.videoCoverScaleUniformBuffer, 0, new Float32Array([1, 1, 0, 0]));
+
     // Initialize Frosted Glass Backboard
     await this.initFrostedGlassBackboard();
     

--- a/src/webgpu/renderers/backgroundRenderer.ts
+++ b/src/webgpu/renderers/backgroundRenderer.ts
@@ -4,9 +4,12 @@ type BackgroundView = {
   backgroundVertexBuffer: GPUBuffer;
   backgroundBindGroup: GPUBindGroup;
   backgroundUniformBuffer: GPUBuffer;
+  videoCoverScaleUniformBuffer: GPUBuffer;
   sampler: GPUSampler;
   useReactiveVideo: boolean;
   device: GPUDevice;
+  canvasWebGPU: HTMLCanvasElement;
+  reactiveVideoBackground?: { videoElement?: HTMLVideoElement };
 };
 
 export class BackgroundRenderer {
@@ -24,6 +27,7 @@ export class BackgroundRenderer {
 
   draw(passEncoder: GPURenderPassEncoder, isVideoPlaying: boolean, videoTexture: GPUExternalTexture | null) {
     if (isVideoPlaying && videoTexture && this.view.useReactiveVideo) {
+      this.updateCoverScale();
       passEncoder.setPipeline(this.view.videoBackgroundPipeline);
       passEncoder.setVertexBuffer(0, this.view.backgroundVertexBuffer);
       passEncoder.setBindGroup(0, this.createVideoBindGroup(videoTexture));
@@ -37,12 +41,30 @@ export class BackgroundRenderer {
     passEncoder.draw(6);
   }
 
+  /** Computes an object-fit:cover UV scale so the video fills the canvas without stretching. */
+  private updateCoverScale() {
+    const video = this.view.reactiveVideoBackground?.videoElement;
+    const videoWidth = video?.videoWidth || 0;
+    const videoHeight = video?.videoHeight || 0;
+    if (!videoWidth || !videoHeight) return;
+
+    const canvasAspect = this.view.canvasWebGPU.width / this.view.canvasWebGPU.height;
+    const videoAspect = videoWidth / videoHeight;
+    const ratio = canvasAspect / videoAspect;
+
+    const scaleX = ratio >= 1 ? 1 : ratio;
+    const scaleY = ratio >= 1 ? 1 / ratio : 1;
+
+    this.view.device.queue.writeBuffer(this.view.videoCoverScaleUniformBuffer, 0, new Float32Array([scaleX, scaleY, 0, 0]));
+  }
+
   private createVideoBindGroup(videoTexture: GPUExternalTexture): GPUBindGroup {
     return this.view.device.createBindGroup({
       layout: this.view.videoBackgroundPipeline.getBindGroupLayout(0),
       entries: [
         { binding: 0, resource: this.view.sampler },
         { binding: 1, resource: videoTexture },
+        { binding: 2, resource: { buffer: this.view.videoCoverScaleUniformBuffer } },
       ],
     });
   }

--- a/src/webgpu/shaders/videoBackground.ts
+++ b/src/webgpu/shaders/videoBackground.ts
@@ -18,6 +18,8 @@ export function VideoBackgroundShaders() {
     fragment: `
       @group(0) @binding(0) var videoSampler: sampler;
       @group(0) @binding(1) var videoTex: texture_external;
+      // xy = UV scale that crops the video to a "cover" fit (preserves aspect ratio).
+      @group(0) @binding(2) var<uniform> coverScale: vec4<f32>;
 
       struct FragmentInput {
         @location(0) uv: vec2<f32>
@@ -25,7 +27,8 @@ export function VideoBackgroundShaders() {
 
       @fragment
       fn main(input: FragmentInput) -> @location(0) vec4<f32> {
-        let color = textureSampleBaseClampToEdge(videoTex, videoSampler, input.uv);
+        let uv = (input.uv - 0.5) * coverScale.xy + 0.5;
+        let color = textureSampleBaseClampToEdge(videoTex, videoSampler, uv);
         return color;
       }
     `


### PR DESCRIPTION
## Summary
- The WebGPU `texture_external` video background pipeline mapped UVs 0..1 straight across the canvas with no aspect-ratio correction, so the video was stretched to whatever the canvas aspect happened to be.
- Added a per-frame `coverScale` uniform computed from canvas vs. video aspect ratio, applied in the video background fragment shader to crop the video like CSS `object-fit: cover` instead of stretching it.

## Still open
- The gold/glass piece styling request from go.1ink.us/tetris is still being investigated — waiting on a reference screenshot to compare against the current `imageSampled` block.png texture path before changing anything there.

## Test plan
- [x] `npx tsc --noEmit` shows no new errors introduced
- [x] `npx vitest run` — 62/62 passing
- [ ] Visual check in a WebGPU-capable browser (not possible in this sandboxed container — no GPU/browser available)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EP9u3iuS219KtHFXCP2GjH)_