### PR TITLE
feat: Add CRT scanline jitter on hard drops

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -38,3 +38,4 @@
 - "Implemented Next-Level Juice Protocol: Upgraded the WebGPU background shader (`background.ts`) to dynamically evolve into a luxury glowing glass-brick wall. The grid features crack propagation that intensifies with the game level and combo multiplier (`warpSurge`), along with glowing mortar and gold/silver hinges that throb with intensity."
 - "Adding additive blending to the particle shader makes the explosions look like real light."
 - "Screen shake should decay exponentially, not linearly, for a snappier feel."
+- "Added intense CRT scanline jitter that specifically scales with hardDropBoost to make the CRT distortion heavily react to impacts and give hard drops an even punchier Arcade feel."

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -104,7 +104,10 @@ export const EnhancedPostProcessShaders = () => {
             let scanlineY = curvedUV.y * uniforms.screenHeight;
             var scanline = sin(scanlineY * 3.14159) * 0.5 + 0.5;
             scanline = scanline * sqrt(scanline); // pow(scanline, 1.5)
-            scanline = 0.9 + scanline * 0.1;
+
+            // NEON BRICKLAYER: Intense CRT scanline jitter on hard drop boost
+            let crtJitter = sin(scanlineY * 2.0 - uniforms.time * 50.0) * 0.2 * uniforms.hardDropBoost;
+            scanline = 0.9 + scanline * 0.1 - crtJitter;
             
             // RGB pixel separation (mask effect)
             let maskX = curvedUV.x * uniforms.screenWidth;
@@ -327,8 +330,10 @@ export const EnhancedPostProcessShaders = () => {
             }
 
             // Simple scanlines overlay
-            let scanline = sin(finalUV.y * 600.0 + uniforms.time * 10.0) * 0.02;
-            color -= vec3<f32>(scanline);
+            let baseScanline = sin(finalUV.y * 600.0 + uniforms.time * 10.0) * 0.02;
+            // NEON BRICKLAYER: Add intense CRT jitter on hard drop boost
+            let overlayJitter = sin(finalUV.y * 1200.0 - uniforms.time * 50.0) * 0.15 * uniforms.hardDropBoost;
+            color -= vec3<f32>(baseScanline + overlayJitter);
 
             // Fade the kaleido (if active)
             if (uniforms.gameOverKaleidoTime > 0.001) {

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -117,7 +117,10 @@ export const MaterialAwarePostProcessShaders = () => {
             let scanlineY = curvedUV.y * uniforms.screenHeight;
             var scanline = sin(scanlineY * 3.14159) * 0.5 + 0.5;
             scanline = scanline * sqrt(scanline); // pow(scanline, 1.5)
-            scanline = 0.9 + scanline * 0.1;
+
+            // NEON BRICKLAYER: Intense CRT scanline jitter on hard drop boost
+            let crtJitter = sin(scanlineY * 2.0 - uniforms.time * 50.0) * 0.2 * uniforms.hardDropBoost;
+            scanline = 0.9 + scanline * 0.1 - crtJitter;
             
             // RGB pixel separation (mask effect)
             let maskX = curvedUV.x * uniforms.screenWidth;
@@ -378,8 +381,10 @@ export const MaterialAwarePostProcessShaders = () => {
             }
 
             // Subtle scanlines overlay
-            let scanline = sin(finalUV.y * 600.0 + uniforms.time * 10.0) * 0.015;
-            color -= vec3<f32>(scanline);
+            let baseScanline = sin(finalUV.y * 600.0 + uniforms.time * 10.0) * 0.015;
+            // NEON BRICKLAYER: Add intense CRT jitter on hard drop boost
+            let overlayJitter = sin(finalUV.y * 1200.0 - uniforms.time * 50.0) * 0.15 * uniforms.hardDropBoost;
+            color -= vec3<f32>(baseScanline + overlayJitter);
 
             // Fade the kaleido (if active)
             if (uniforms.gameOverKaleidoTime > 0.001) {

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -285,8 +285,10 @@ export const PostProcessShaders = () => {
                 // 6-way mirror fold
                 a = abs( (a / sa) % 2.0 - 1.0 ) * sa;
             // Scanlines
-            let scanline = sin(finalUV.y * 800.0 + uniforms.time * 10.0) * 0.04;
-            color -= vec3<f32>(scanline);
+            let baseScanline = sin(finalUV.y * 800.0 + uniforms.time * 10.0) * 0.04;
+            // NEON BRICKLAYER: Add intense CRT jitter on hard drop boost
+            let crtJitter = sin(finalUV.y * 1200.0 - uniforms.time * 50.0) * 0.15 * uniforms.hardDropBoost;
+            color -= vec3<f32>(baseScanline + crtJitter);
 
             // Fade the kaleido (if active) as the 2s timer expires (hands off to HTML overlay)
             if (uniforms.gameOverKaleidoTime > 0.001) {


### PR DESCRIPTION
Adds a highly requested "juice" visual effect where hard drops trigger an intense CRT scanline jitter across all post-processing pipelines.

---
*PR created automatically by Jules for task [16546199870627837160](https://jules.google.com/task/16546199870627837160) started by @ford442*