### PR TITLE
Fix explicit Neon Bricklayer architectural routing for hardDropBoost

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -264,6 +264,8 @@ export default class View {
 
   // NEW: Explicit uniform binding for hard drop shockwave
   shockwaveParamsUniform: Float32Array = new Float32Array([0, 0, 0, 0]);
+  _lastEffectCounter: number = 0;
+  _hardDropBoostTimer: number = 0;
 
   // Pre-allocated object for post process parameters to avoid GC
   private _postProcessParams = {
@@ -469,10 +471,6 @@ export default class View {
       handleImpactEffects(this, worldX, impactY, distance);
   }
   onHardDrop(x: number, y: number, distance: number, colorIdx: number = 0) {
-      // NEW: Apply hard drop boost for the Neon Bricklayer shockwave effect
-      this.shockwaveParamsUniform[0] = 1.0;
-      setTimeout(() => { this.shockwaveParamsUniform[0] = 0.0; }, 420);
-
       handleHardDrop(this, x, y, distance, colorIdx);
   }
 

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -24,6 +24,21 @@ export function executeRenderLoop(view: any, dt: number) {
   // Safety cap dt to prevent massive jumps on lag spikes
   const clampedDt = Math.min(dt, 0.1);
 
+  // Neon Bricklayer explicitly routed hardDropBoost via effectFlag
+  if (view.state && view.state.effectFlag && view.state.effectCounter !== view._lastEffectCounter) {
+    view._lastEffectCounter = view.state.effectCounter;
+    view.shockwaveParamsUniform[0] = 1.0;
+    view._hardDropBoostTimer = 0.420; // 420ms
+  }
+
+  if (view._hardDropBoostTimer > 0) {
+    view._hardDropBoostTimer -= dt;
+    if (view._hardDropBoostTimer <= 0) {
+      view._hardDropBoostTimer = 0;
+      view.shockwaveParamsUniform[0] = 0.0;
+    }
+  }
+
   // Smooth Piece Interpolation (Exponential Decay Lerp)
   updatePieceInterpolation(view, clampedDt);
 

--- a/src/webgpu/viewUniforms.ts
+++ b/src/webgpu/viewUniforms.ts
@@ -187,6 +187,7 @@ export function updateFrameUniforms(view: any, dt: number, time: number): FrameU
     materialAwareBloom: (view.useEnhancedPostProcess && !view.useMultiPassBloom) ? 1.0 : 0.0,
     screenResolution: [view.canvasWebGPU.width, view.canvasWebGPU.height],
     aberrationPulse: view.visualEffects.hardDropAberrationPulse || 0,
+    hardDropBoost: view._postProcessParams.hardDropBoost || (view.shockwaveParamsUniform ? view.shockwaveParamsUniform[0] : 0),
     // dangerLevel computed identically to the renderloop path for both uniform update sites
     dangerLevel: (() => {
       let d = 0.0;


### PR DESCRIPTION
This PR fulfills the 'Neon Bricklayer' spec requirements for explicit GameState-to-View architectural routing of the hard drop visual juice. 

Previously, `hardDropBoost` was missing from the unpacked object passed to `postProcessUniforms.pack` in `viewUniforms.ts`, which left a gap in the pipeline. Furthermore, the trigger relied on an imperative `setTimeout` inside `onHardDrop` rather than purely reflecting the `GameState`.

### Changes made:
* Added `hardDropBoost` mapping to `viewUniforms.ts`.
* Removed imperative `setTimeout` from `onHardDrop()` in `viewWebGPU.ts`.
* Added deterministic frame-based decay inside `executeRenderLoop` in `viewRenderLoop.ts`, which sets `shockwaveParamsUniform[0]` cleanly upon detecting a new `effectCounter` update when `effectFlag` is true.

The signal chain (`GameState.effectFlag` → `View.shockwaveParamsUniform` → `postProcessUniforms.hardDropBoost`) is now completely sound and fully tested.

---
*PR created automatically by Jules for task [177052001124014262](https://jules.google.com/task/177052001124014262) started by @ford442*