### PR TITLE
GPU-resident clear-dissolve field (compute writes, block shader reads)

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -12,7 +12,7 @@ import {
   Shaders,
   PremiumBlockShaders,
 } from './webgpu/shaders.js';
-import { ParticleComputeShader } from './webgpu/compute.js';
+import { ParticleComputeShader, DissolveComputeShader } from './webgpu/compute.js';
 import { JellyfishParticleSystem } from './webgpu/jellyfishParticles.js';
 import { CubeData, FullScreenQuadData, GridData } from './webgpu/geometry.js';
 import {
@@ -199,7 +199,17 @@ export default class View {
   particleRenderBindGroup!: GPUBindGroup;
   particleComputePipeline!: GPUComputePipeline;
   particleUniformBuffer!: GPUBuffer; // Added missing declaration
-  
+
+  // Clear-dissolve field (GPU-resident, GPU-consumed). Compute writes a 10x20 f32
+  // progress buffer that the block fragment shader samples to glow cleared cells.
+  dissolveBuffer!: GPUBuffer;
+  dissolveComputePipeline!: GPUComputePipeline;
+  dissolveComputeBindGroup!: GPUBindGroup;
+  dissolveComputeUniformBuffer!: GPUBuffer;
+  private _dissolveUniform = new Float32Array(24);   // dt, decayRate, pad2, rowClear[20]
+  private _dissolveActiveTimer = 0;                  // seconds remaining of active fade
+  private _dissolveFadeSeconds = 0.3;
+
   // Subsystems
   particleSystem: ParticleSystem;
   jellyfishSystem: JellyfishParticleSystem; // NEW: Bioluminescent jellyfish
@@ -460,7 +470,10 @@ export default class View {
   onLineClear(lines: number[], tSpin: boolean = false, combo: number = 0, backToBack: boolean = false, isAllClear: boolean = false) {
       // Trigger DOM-based line flash effect
       lineFlashEffect.flashLines(lines);
-      
+
+      // Push cleared rows DOWN to the GPU dissolve field (compute re-arms them to 1.0).
+      this.triggerDissolve(lines);
+
       // Trigger the main line clear effects
       handleLineClear(this, lines, tSpin, combo, backToBack, isAllClear);
   }
@@ -857,6 +870,28 @@ export default class View {
     (this as any).postProcessUniforms = (this as any).postProcessUniforms || {};
     (this as any).postProcessUniforms.shockwaveParams = this.shockwaveParams;
 
+    // --- Clear-dissolve field (GPU compute writes, block fragment reads) ---
+    // 10x20 f32 storage buffer, indexed row*10+col (matches the CPU playfield).
+    this.dissolveBuffer = this.device.createBuffer({
+      size: 200 * 4,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    this.dissolveComputeUniformBuffer = this.device.createBuffer({
+      size: 96, // dt + decayRate + pad(8) + rowClear array<vec4,5>(80)
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this.dissolveComputePipeline = this.device.createComputePipeline({
+      label: 'dissolve compute pipeline', layout: 'auto',
+      compute: { module: this.device.createShaderModule({ code: DissolveComputeShader }), entryPoint: 'main' },
+    });
+    this.dissolveComputeBindGroup = this.device.createBindGroup({
+      layout: this.dissolveComputePipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: this.dissolveBuffer } },
+        { binding: 1, resource: { buffer: this.dissolveComputeUniformBuffer } },
+      ],
+    });
+
     this.renderPlayfield_Border_WebGPU();
 
     this.vertexUniformBuffer = this.device.createBuffer({
@@ -874,6 +909,7 @@ export default class View {
                 { binding: 1, resource: { buffer: this.fragmentUniformBuffer, offset: 0, size: UNIFORM_BUFFER_SIZES.FRAGMENT } },
                 { binding: 2, resource: createBlockTextureBindingView(this.blockTexture) },
                 { binding: 3, resource: this.blockSampler },
+                { binding: 5, resource: { buffer: this.dissolveBuffer } },
             ],
         });
         this.uniformBindGroup_CACHE.push(bindGroup);
@@ -909,6 +945,38 @@ export default class View {
 
   render(dt: number) {
     executeRenderLoop(this, dt);
+  }
+
+  // Flag the cleared rows in the dissolve uniform and arm the fade window. The flags
+  // are consumed (and cleared) by the next dissolve compute dispatch in the render loop.
+  triggerDissolve(lines: number[]) {
+    if (!lines || lines.length === 0) return;
+    for (const row of lines) {
+      if (row >= 0 && row < 20) this._dissolveUniform[4 + row] = 1.0;
+    }
+    this._dissolveActiveTimer = this._dissolveFadeSeconds;
+  }
+
+  // Run the dissolve compute pass while the fade is active. Writes dt + row flags,
+  // dispatches the compute shader, then clears the one-shot flags. CPU only pushes
+  // state down; the field is read back exclusively on the GPU by the block shader.
+  dispatchDissolveCompute(commandEncoder: GPUCommandEncoder, dt: number) {
+    if (!this.device || !this.dissolveComputePipeline) return;
+    if (this._dissolveActiveTimer <= 0) return;
+    this._dissolveActiveTimer = Math.max(0, this._dissolveActiveTimer - dt);
+
+    this._dissolveUniform[0] = dt;
+    this._dissolveUniform[1] = 1.0 / this._dissolveFadeSeconds;
+    this.device.queue.writeBuffer(this.dissolveComputeUniformBuffer, 0, this._dissolveUniform);
+
+    const pass = commandEncoder.beginComputePass();
+    pass.setPipeline(this.dissolveComputePipeline);
+    pass.setBindGroup(0, this.dissolveComputeBindGroup);
+    pass.dispatchWorkgroups(Math.ceil(200 / 64));
+    pass.end();
+
+    // Row-clear flags are one-shot; clear them so they only re-arm on a new clear.
+    for (let r = 0; r < 20; r++) this._dissolveUniform[4 + r] = 0.0;
   }
 
   // Pre-allocated buffer for batched uniform updates (max 200 blocks * 64 floats per block)

--- a/src/webgpu/compute.ts
+++ b/src/webgpu/compute.ts
@@ -1,3 +1,40 @@
+// ============================================================================
+// CLEAR-DISSOLVE COMPUTE SHADER
+// Maintains a GPU-resident 10x20 f32 field of per-cell "dissolve progress".
+// CPU pushes DOWN which rows cleared this frame (rowClear flags) + dt; the field
+// decays toward 0 over ~300ms and is re-armed to 1.0 for freshly cleared rows.
+// The block fragment shader (pbrBlocks) samples this same storage buffer to glow
+// cleared cells — compute writes, fragment reads, zero round-trip to the CPU.
+// ============================================================================
+export const DissolveComputeShader = `
+struct DissolveUniforms {
+  dt        : f32,                 // seconds elapsed this frame
+  decayRate : f32,                 // 1.0 / fadeSeconds (e.g. 1/0.3)
+  _pad      : vec2<f32>,
+  rowClear  : array<vec4<f32>, 5>, // 20 row flags (1.0 = cleared this frame)
+};
+
+@group(0) @binding(0) var<storage, read_write> dissolve : array<f32, 200>;
+@group(0) @binding(1) var<uniform> u : DissolveUniforms;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
+  let i = GlobalInvocationID.x;
+  if (i >= 200u) {
+    return;
+  }
+  let row = i / 10u;
+  // Decay existing progress toward 0.
+  var v = dissolve[i] - u.dt * u.decayRate;
+  // Re-arm cells in rows cleared this frame.
+  let flag = u.rowClear[row / 4u][row % 4u];
+  if (flag > 0.5) {
+    v = 1.0;
+  }
+  dissolve[i] = clamp(v, 0.0, 1.0);
+}
+`;
+
 export const ParticleComputeShader = `
 struct Particle {
   pos : vec3<f32>,       // offset 0

--- a/src/webgpu/renderers/blockRenderer.ts
+++ b/src/webgpu/renderers/blockRenderer.ts
@@ -26,6 +26,7 @@ type BlockView = {
   uvBuffer: GPUBuffer;
   uniformBindGroup_ARRAY_border: GPUBindGroup[];
   vertexUniformBuffer_border: GPUBuffer;
+  dissolveBuffer: GPUBuffer;
 };
 
 export class BlockRenderer {
@@ -49,6 +50,7 @@ export class BlockRenderer {
       this.view.blockTexture, this.view.blockSampler,
       this.view.vpMatrix as Float32Array, this.view.currentTheme,
       this.view._f32_3, this.view._f32_4, this.view.MODELMATRIX, this.view.NORMALMATRIX,
+      this.view.dissolveBuffer,
     );
     this.view.vertexUniformBuffer_border = result.vertexUniformBuffer;
     this.view.uniformBindGroup_ARRAY_border = result.bindGroups;

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -150,6 +150,9 @@ export const PBRBlockShaders = () => {
         @binding(1) @group(0) var<uniform> fUniforms : FragmentUniforms;
         @binding(2) @group(0) var blockTexture : texture_2d<f32>;
         @binding(3) @group(0) var blockSampler : sampler;
+        // GPU-resident clear-dissolve field: 10x20 f32 (row*10+col), written by the
+        // dissolve compute pass and read here. Compute writes, fragment reads — no readback.
+        @binding(5) @group(0) var<storage, read> dissolveField : array<f32, 200>;
 
         ${PBRFunctions}
         
@@ -434,8 +437,10 @@ export const PBRBlockShaders = () => {
                 // Opaque gold frame; stained-glass window stays readable over the video portal.
                 let edgeFresnel = 1.0 - NdotV;
                 let fresnelSq = edgeFresnel * edgeFresnel;
-                let glassOpacity = mix(0.82, 0.97, fresnelSq);
-                finalAlpha = mix(1.0, glassOpacity, combinedGlassMask);
+                let glassMin = 0.82;
+                let glassMax = 0.97;
+                let glassOpacity = mix(glassMin, glassMax, fresnelSq);
+                finalAlpha = mix(1.0, glassOpacity, glassMaskAlpha);
             } else if (fUniforms.enablePBR < 0.5 || materialType == 0u) {
                 // Classic mode
                 let lightFactor = 0.4 + NdotL * 0.6;
@@ -599,6 +604,20 @@ export const PBRBlockShaders = () => {
             }
 
             finalColor = clamp(finalColor, vec3f(0.0), vec3f(1.0));
+
+            // === GPU CLEAR-DISSOLVE GLOW ===
+            // Sample the compute-written per-cell dissolve field (0..1, decays ~300ms).
+            // Cell index derived from world position (same /BLOCK_WORLD_SIZE mapping as
+            // columnHeights above). Additive post-clamp so the fading glow can bloom.
+            {
+                let dCol = i32(clamp(floor(vWorldPos.x / 2.2 + 0.0001), 0.0, 9.0));
+                let dRow = i32(clamp(floor(-vWorldPos.y / 2.2 + 0.0001), 0.0, 19.0));
+                let dissolveVal = dissolveField[dRow * 10 + dCol];
+                if (dissolveVal > 0.001) {
+                    finalColor += vec3f(0.55, 0.9, 1.0) * dissolveVal * 2.2;
+                }
+            }
+
             // Use the hard metal mask for opacity so the frame never becomes semi-transparent.
             let materialAlpha = mix(finalAlpha, 1.0, metalMaskForAlpha);
             let outAlpha = materialAlpha * vColor.w;

--- a/src/webgpu/viewPlayfield.ts
+++ b/src/webgpu/viewPlayfield.ts
@@ -267,6 +267,7 @@ export function renderPlayfieldBorder(
   _f32_4: Float32Array,
   MODELMATRIX: Matrix.mat4,
   NORMALMATRIX: Matrix.mat4,
+  dissolveBuffer: GPUBuffer,
 ): { vertexUniformBuffer: GPUBuffer; bindGroups: GPUBindGroup[] } {
   const state_Border = {
     playfield: [
@@ -292,6 +293,7 @@ export function renderPlayfieldBorder(
           { binding: 1, resource: { buffer: fragmentUniformBuffer, offset: 0, size: UNIFORM_BUFFER_SIZES.FRAGMENT } },
           { binding: 2, resource: createBlockTextureBindingView(blockTexture) },
           { binding: 3, resource: blockSampler },
+          { binding: 5, resource: { buffer: dissolveBuffer } },
         ],
       });
 

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -67,6 +67,10 @@ export function executeRenderLoop(view: any, dt: number) {
     computePass.end();
   }
 
+  // Clear-dissolve field: GPU compute writes the per-cell fade buffer the block
+  // fragment shader samples. Self-gated; only runs during the ~300ms post-clear window.
+  view.dispatchDissolveCompute?.(commandEncoder, clampedDt);
+
   // Update render uniforms
   updateRenderUniforms(view, time, result);
 

--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,0 +1,31 @@
+# Weekly Plan
+
+## GPU-resident clear-dissolve field
+
+Goal: demonstrate the CPU-authoritative → GPU-pushed → GPU-consumed pattern with a
+single per-cell visual field. When `lineUtils` clears rows, a compute shader writes a
+10×20 f32 buffer of dissolve progress (0..1, decaying over ~300ms) that the playfield
+block fragment shader samples to glow cleared cells. No `mapAsync`, no readback.
+
+### Done
+- **Fix First**: `pbrBlocks.ts` authored glass path used an undefined `combinedGlassMask`
+  identifier (WGSL compile error) and a literal `mix(0.82, 0.97, …)` that diverged from the
+  documented intent. Restored to `glassMin`/`glassMax` constants + `glassMaskAlpha`, matching
+  `tests/shader-optimizations.test.ts` (was 1 failing test, now green).
+- Added `dissolveBuffer` (200 × f32 storage, indexed `row*10+col`) — GPU-resident,
+  zero round-trip. Bound to BOTH the dissolve compute pass (`read_write`, binding 0) and
+  the block render pipeline (`read`, `@binding(5) @group(0)`).
+- Added `DissolveComputeShader` in `webgpu/compute.ts` (next to the particle compute shader):
+  decays every cell by `dt/0.3`, re-arms rows flagged this frame to `1.0`.
+- `viewWebGPU.onLineClear` → `triggerDissolve(lines)` pushes cleared rows DOWN into the
+  compute uniform (`dt`, `decayRate`, `rowClear[20]`); `dispatchDissolveCompute` runs the
+  pass only during the ~300ms post-clear window (self-gated, no per-frame cost otherwise).
+- Block fragment shader (`pbrBlocks`) derives cell from `vWorldPos` (reusing the existing
+  `/BLOCK_WORLD_SIZE` mapping) and adds an additive cyan glow scaled by the field value;
+  alpha untouched so shifted blocks don't flicker.
+- Added binding 5 (shared `dissolveBuffer`) to `uniformBindGroup_CACHE` (viewWebGPU) and the
+  border bind groups (viewPlayfield) so the `layout:"auto"` block pipeline stays valid.
+
+### Last Run
+- `npm run build` — ✅ built in ~1.2s (90 modules).
+- `npm run test` — ✅ 62 passed (11 files). Previously 1 failing (pre-existing glass-path bug).


### PR DESCRIPTION
## What

Adds **one** GPU-resident, GPU-consumed visual field to demonstrate the CPU-authoritative → GPU-pushed → GPU-consumed pattern: a per-cell **clear-dissolve** field. When `lineUtils` clears rows, a compute shader writes a 10×20 `f32` buffer of dissolve progress (0..1, decaying over ~300 ms) and the playfield block fragment shader samples it to glow cleared cells.

Game-logic correctness is untouched — the CPU remains the sole authority over the `Int8Array` playfield; only board state is pushed *down* to the GPU.

## How it satisfies the constraints

- **CPU stays authoritative.** `onLineClear(lines)` → `triggerDissolve(lines)` pushes the cleared row indices down into the compute uniform. Nothing derived is ever read back.
- **No `mapAsync` / no readback.** `dissolveBuffer` (200 × f32, indexed `row*10+col`) is bound to **both** the dissolve compute pass (`read_write`, binding 0) and the existing block render pipeline (`read`, `@binding(5) @group(0)`). Compute writes, fragment reads, zero round-trip.
- **Reuses existing plumbing.** `DissolveComputeShader` lives in `webgpu/compute.ts` next to the particle compute shader; the pass is dispatched in `viewRenderLoop` alongside the particle compute pass using the same `commandEncoder`. No second WebGPU init path.
- **Self-gated.** The compute pass only runs during the ~300 ms post-clear window, so there's no steady-state per-frame cost.
- Binding 5 (the shared `dissolveBuffer`) was added to `uniformBindGroup_CACHE` (viewWebGPU) and the border bind groups (viewPlayfield) so the `layout:"auto"` block pipeline stays valid.

## Fix First

`pbrBlocks.ts` authored-glass path referenced an **undefined** `combinedGlassMask` (a WGSL compile error) and used a literal `mix(0.82, 0.97, …)` that diverged from the documented intent. Restored to `glassMin`/`glassMax` constants + `glassMaskAlpha`, matching `tests/shader-optimizations.test.ts` — this test was already failing before this PR (1 failing) and is now green.

## Verification

- `npm run build` — ✅ built in ~1.2 s (90 modules)
- `npm run test` — ✅ 62 passed (11 files); previously 1 failing (the pre-existing glass-path bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Makhbyo2bePtzniEwk28Z2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Makhbyo2bePtzniEwk28Z2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a visual clear-dissolve effect: when rows are cleared, they now display an additive cyan glow that gradually fades over time, creating a more polished clearing animation.

* **Documentation**
  * Added feature planning documentation for the clear-dissolve visual pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->