### PR TITLE
Wire in gold glass texture for shockwave effect

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -42,3 +42,4 @@
 - "Added a 'Shockwave' distortion effect on Hard Drops."
 - "Upgraded Block shaders to include Fresnel Rim Lighting and Pulse effects."
 - "Evolved the BackgroundShaders to react to the Game Level (calm blue at Lvl 1, chaotic red at Lvl 10)."
+- "Wired in the gold cracked-glass texture as a subtle dynamic overlay during the hard drop shockwave post-processing effect, extracting bright highlights from the block texture to simulate a shattering impact."

--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -827,7 +827,12 @@ export default class View {
 
     this.postProcessBindGroup = this.device.createBindGroup({
         layout: this.postProcessPipeline.getBindGroupLayout(0),
-        entries: [{ binding: 0, resource: { buffer: this.postProcessUniformBuffer } }, { binding: 1, resource: this.sampler }, { binding: 2, resource: this.offscreenTexture.createView() }]
+        entries: [
+            { binding: 0, resource: { buffer: this.postProcessUniformBuffer } },
+            { binding: 1, resource: this.sampler },
+            { binding: 2, resource: this.offscreenTexture.createView() },
+            { binding: 3, resource: createBlockTextureBindingView(this.blockTexture) }
+        ]
     });
 
     // Initialize multi-pass bloom system

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -27,6 +27,7 @@ export const EnhancedPostProcessShaders = () => {
         @binding(0) @group(0) var<uniform> uniforms : PostProcessUniforms;
         @binding(1) @group(0) var mySampler: sampler;
         @binding(2) @group(0) var myTexture: texture_2d<f32>;
+        @binding(3) @group(0) var blockTexture: texture_2d<f32>;
 
         // FXAA 3.11 implementation (simplified)
         // Restructured to avoid non-uniform control flow with textureSample
@@ -213,6 +214,7 @@ export const EnhancedPostProcessShaders = () => {
             let level = uniforms.level;
 
             var shockwaveAberration = 0.0;
+            var glassOverlay = 0.0;
             if (time > 0.0 && time < 1.0) {
                 let dir = normalize(uv - center);
                 let dist = length(uv - center);
@@ -230,6 +232,22 @@ export const EnhancedPostProcessShaders = () => {
                     // NEON BRICKLAYER: Increased shockwave intensity + chromatic aberration on hard drops
                     // for maximum "drop impact" feel (per Graphics & Game Feel requirements)
                     shockwaveAberration = params.z * 3.0 * (1.0 - abs(diff)/width) * (1.0 - time);
+
+                    // NEON BRICKLAYER: Add shattered glass overlay near epicenter
+                    if (uniforms.hardDropBoost > 0.0 && time < 0.5) {
+                        // UVs mapped to the glass block texture, centered at the shockwave epicenter
+                        let glassUV = (uv - center) * 4.0 + vec2<f32>(0.5);
+                        let texColor = textureSampleLevel(blockTexture, mySampler, glassUV, 0.0).rgb;
+
+                        if (glassUV.x >= 0.0 && glassUV.x <= 1.0 && glassUV.y >= 0.0 && glassUV.y <= 1.0) {
+                            // Extract 'cracks' or bright highlights from the gold glass texture
+                            let crackIntensity = max(texColor.r, max(texColor.g, texColor.b));
+
+                            // Blend it smoothly based on distance to the shockwave ring
+                            let blend = cos(angle) * strength * (1.0 - time * 2.0) * uniforms.hardDropBoost * 2.0;
+                            glassOverlay = clamp(crackIntensity * blend, 0.0, 1.0);
+                        }
+                    }
                 }
 
                 // Echo rings
@@ -280,6 +298,11 @@ export const EnhancedPostProcessShaders = () => {
             var g = baseSample.g;
             var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB, vertAberration + pulseR * 0.4)).b;
             var color = vec3<f32>(r, g, b);
+
+            // Add the shattered glass overlay into the final color
+            var glassOverlayColor = vec3<f32>(0.4, 0.8, 1.0) * glassOverlay;
+            color += glassOverlayColor;
+
             let sampledAlpha = baseSample.a;
 
             // FXAA - always call to maintain uniform control flow

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -40,6 +40,7 @@ export const MaterialAwarePostProcessShaders = () => {
         @binding(0) @group(0) var<uniform> uniforms : PostProcessUniforms;
         @binding(1) @group(0) var mySampler: sampler;
         @binding(2) @group(0) var myTexture: texture_2d<f32>;
+        @binding(3) @group(0) var blockTexture: texture_2d<f32>;
 
         // FXAA 3.11 implementation (simplified for performance)
         // Restructured to avoid non-uniform control flow with textureSample
@@ -263,6 +264,7 @@ export const MaterialAwarePostProcessShaders = () => {
             let level = uniforms.level;
 
             var shockwaveAberration = 0.0;
+            var glassOverlay = 0.0;
             if (time > 0.0 && time < 1.0) {
                 let dir = normalize(uv - center);
                 let dist = length(uv - center);
@@ -280,6 +282,22 @@ export const MaterialAwarePostProcessShaders = () => {
                     // NEON BRICKLAYER: Increased shockwave intensity + chromatic aberration on hard drops
                     // for maximum "drop impact" feel (per Graphics & Game Feel requirements)
                     shockwaveAberration = params.z * 3.0 * (1.0 - abs(diff)/width) * (1.0 - time);
+
+                    // NEON BRICKLAYER: Add shattered glass overlay near epicenter
+                    if (uniforms.hardDropBoost > 0.0 && time < 0.5) {
+                        // UVs mapped to the glass block texture, centered at the shockwave epicenter
+                        let glassUV = (uv - center) * 4.0 + vec2<f32>(0.5);
+                        let texColor = textureSampleLevel(blockTexture, mySampler, glassUV, 0.0).rgb;
+
+                        if (glassUV.x >= 0.0 && glassUV.x <= 1.0 && glassUV.y >= 0.0 && glassUV.y <= 1.0) {
+                            // Extract 'cracks' or bright highlights from the gold glass texture
+                            let crackIntensity = max(texColor.r, max(texColor.g, texColor.b));
+
+                            // Blend it smoothly based on distance to the shockwave ring
+                            let blend = cos(angle) * strength * (1.0 - time * 2.0) * uniforms.hardDropBoost * 2.0;
+                            glassOverlay = clamp(crackIntensity * blend, 0.0, 1.0);
+                        }
+                    }
                 }
 
                 // Echo rings
@@ -330,6 +348,11 @@ export const MaterialAwarePostProcessShaders = () => {
             var g = baseSample.g;
             var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB, vertAberration + pulseR * 0.4)).b;
             var color = vec3<f32>(r, g, b);
+
+            // Add the shattered glass overlay into the final color
+            var glassOverlayColor = vec3<f32>(0.4, 0.8, 1.0) * glassOverlay;
+            color += glassOverlayColor;
+
             let sampledAlpha = baseSample.a;
 
             // FXAA

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -27,6 +27,7 @@ export const PostProcessShaders = () => {
         @binding(0) @group(0) var<uniform> uniforms : PostProcessUniforms;
         @binding(1) @group(0) var mySampler: sampler;
         @binding(2) @group(0) var myTexture: texture_2d<f32>;
+        @binding(3) @group(0) var blockTexture: texture_2d<f32>;
 
         @fragment
         fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
@@ -85,6 +86,7 @@ export const PostProcessShaders = () => {
             // === EXPLICIT SHOCKWAVE EFFECT AS REQUESTED ===
             // Shockwave Logic
             var shockwaveAberration = 0.0;
+            var glassOverlay = 0.0;
 
             // Shockwave distortion effect for hard drops
             if (params.y > 0.0) {
@@ -115,6 +117,22 @@ export const PostProcessShaders = () => {
                     // NEON BRICKLAYER: Increased shockwave intensity + chromatic aberration on hard drops
                     // for maximum "drop impact" feel (per Graphics & Game Feel requirements)
                     shockwaveAberration = params.z * 3.0 * (1.0 - abs(diff)/width) * (1.0 - time);
+
+                    // NEON BRICKLAYER: Add shattered glass overlay near epicenter
+                    if (uniforms.hardDropBoost > 0.0 && time < 0.5) {
+                        // UVs mapped to the glass block texture, centered at the shockwave epicenter
+                        let glassUV = (uv - center) * 4.0 + vec2<f32>(0.5);
+                        let texColor = textureSampleLevel(blockTexture, mySampler, glassUV, 0.0).rgb;
+
+                        if (glassUV.x >= 0.0 && glassUV.x <= 1.0 && glassUV.y >= 0.0 && glassUV.y <= 1.0) {
+                            // Extract 'cracks' or bright highlights from the gold glass texture
+                            let crackIntensity = max(texColor.r, max(texColor.g, texColor.b));
+
+                            // Blend it smoothly based on distance to the shockwave ring
+                            let blend = cos(angle) * strength * (1.0 - time * 2.0) * uniforms.hardDropBoost * 2.0;
+                            glassOverlay = clamp(crackIntensity * blend, 0.0, 1.0);
+                        }
+                    }
                 }
 
                 // Second ring (Echo) - NEON BRICKLAYER
@@ -186,7 +204,7 @@ export const PostProcessShaders = () => {
             let a = baseSample.a;
 
             // Bloom-ish boost (optimized 5-tap tent filter)
-            var color = vec3<f32>(r, g, b);
+            var color = vec3<f32>(r, g, b) + vec3<f32>(0.4, 0.8, 1.0) * glassOverlay;
 
             // OPTIMIZED: 5-tap tent filter (down from 8) with weighted sampling
             // Center + 4 directional samples = better quality, fewer ALU ops

--- a/src/webgpu/viewTextures.ts
+++ b/src/webgpu/viewTextures.ts
@@ -7,6 +7,7 @@ import {
   PROCEDURAL_BLOCK_TEXTURE_SIZE,
   getTextureMipLevelCount,
   paintProceduralBlockTexture,
+  createBlockTextureBindingView,
 } from './blockTexture.js';
 
 /**
@@ -178,6 +179,7 @@ export async function recreateRenderTargets(view: any) {
         { binding: 0, resource: { buffer: view.postProcessUniformBuffer } },
         { binding: 1, resource: view.sampler },
         { binding: 2, resource: view.offscreenTexture.createView() },
+        { binding: 3, resource: createBlockTextureBindingView(view.blockTexture) },
       ],
     });
   }


### PR DESCRIPTION
Wired in the gold cracked-glass texture as a subtle dynamic overlay during the hard drop shockwave post-processing effect, extracting bright highlights from the block texture to simulate a shattering impact. Updated the `neon_bricklayers_journal.md` to reflect this change.

---
*PR created automatically by Jules for task [6892199693125546223](https://jules.google.com/task/6892199693125546223) started by @ford442*