### PR TITLE
feat: implement Fresnel Rim Lighting on block shaders

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -43,3 +43,4 @@
 - "Upgraded Block shaders to include Fresnel Rim Lighting and Pulse effects."
 - "Evolved the BackgroundShaders to react to the Game Level (calm blue at Lvl 1, chaotic red at Lvl 10)."
 - "Wired in the gold cracked-glass texture as a subtle dynamic overlay during the hard drop shockwave post-processing effect, extracting bright highlights from the block texture to simulate a shattering impact."
+- "Implemented explicit Fresnel Rim Lighting on the gold glass blocks! Added a `fresnelParams` uniform in `viewWebGPU.ts` and updated the PBR fragment shader (`pbrBlocks.ts`) to compute a Fresnel term based on the view direction. Wired a `setFresnelBoost()` hook in `game.ts` to dramatically intensify the gold edges when a Hard Drop occurs, creating an awesome additive rim flare during impacts."

--- a/src/game.ts
+++ b/src/game.ts
@@ -247,6 +247,10 @@ export default class Game {
     this.effectCounter++;
     this._gameStateCache.effectFlag = true;
 
+    // Fresnel rim boost during hard drop (Neon Bricklayer task)
+    if (this.view) {
+        (this.view as any).setFresnelBoost?.(1.0);
+    }
     if (this.view && this.view.visualEffects && this.view.visualEffects.triggerShockwave) {
         this.view.visualEffects.triggerShockwave([0.5, 0.5], 0.8, 0.4, 0.15, 3.5);
     }
@@ -290,6 +294,10 @@ export default class Game {
     this.effectCounter++;
     this._gameStateCache.effectFlag = true;
 
+    // Fresnel rim boost during hard drop (Neon Bricklayer task)
+    if (this.view) {
+        (this.view as any).setFresnelBoost?.(1.0);
+    }
     if (this.view && this.view.visualEffects && this.view.visualEffects.triggerShockwave) {
         this.view.visualEffects.triggerShockwave([0.5, 0.5], 0.8, 0.4, 0.15, 3.5);
     }

--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -283,6 +283,16 @@ export default class View {
 
   // NEW: Explicit uniform binding for hard drop shockwave
   shockwaveParamsUniform: Float32Array = new Float32Array([0, 0, 0, 0]);
+
+  // Fresnel Rim Lighting uniform (new for Neon Bricklayer task)
+  fresnelParamsUniform!: GPUBuffer;
+  fresnelParams = {
+      intensity: 0.65,
+      fresnelPower: 2.8,
+      hardDropBoost: 0,
+      _pad1: 0,
+  };
+
   _lastEffectCounter: number = 0;
   _hardDropBoostTimer: number = 0;
 
@@ -853,6 +863,12 @@ export default class View {
     // 224 bytes — WGSL minBindingSize for FragmentUniforms (audio bands at 184+, struct tail padding)
     this.fragmentUniformBuffer = this.device.createBuffer({ size: UNIFORM_BUFFER_SIZES.FRAGMENT, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
 
+    this.fresnelParamsUniform = this.device.createBuffer({
+        size: 16, // vec4<f32> aligned
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        mappedAtCreation: false,
+    });
+
     let eyePosition = [0.0, BOARD_WORLD_CENTER_Y, 75.0];
     let lightPosition = this._f32_3;
     lightPosition.set([-5.0, 0.0, 0.0]);
@@ -945,6 +961,7 @@ export default class View {
                 { binding: 2, resource: createBlockTextureBindingView(this.blockTexture) },
                 { binding: 3, resource: this.blockSampler },
                 { binding: 5, resource: { buffer: this.dissolveBuffer } },
+                { binding: 6, resource: { buffer: this.fresnelParamsUniform } },
             ],
         });
         this.uniformBindGroup_CACHE.push(bindGroup);
@@ -978,7 +995,28 @@ export default class View {
     );
   }
 
+  public setFresnelBoost(boost: number) {
+      this.fresnelParams.hardDropBoost = boost;
+  }
+
   render(dt: number) {
+    // Decay Fresnel boost if any
+    if (this.fresnelParams.hardDropBoost > 0) {
+      this.fresnelParams.hardDropBoost = Math.max(0, this.fresnelParams.hardDropBoost - dt * 2.0); // Simple decay
+    }
+    if (this.device) {
+      this.device.queue.writeBuffer(
+          this.fresnelParamsUniform,
+          0,
+          new Float32Array([
+              this.fresnelParams.intensity,
+              this.fresnelParams.fresnelPower,
+              this.fresnelParams.hardDropBoost,
+              0
+          ])
+      );
+    }
+
     executeRenderLoop(this, dt);
   }
 

--- a/src/webgpu/shaders/pbrBlocks.ts
+++ b/src/webgpu/shaders/pbrBlocks.ts
@@ -154,6 +154,14 @@ export const PBRBlockShaders = () => {
         // dissolve compute pass and read here. Compute writes, fragment reads — no readback.
         @binding(5) @group(0) var<storage, read> dissolveField : array<f32, 200>;
 
+        struct FresnelParams {
+            intensity: f32,
+            fresnelPower: f32,
+            hardDropBoost: f32,
+            _pad1: f32,
+        };
+        @binding(6) @group(0) var<uniform> fresnelParams: FresnelParams;
+
         ${PBRFunctions}
         
         // ============================================================================
@@ -518,13 +526,18 @@ export const PBRBlockShaders = () => {
                 }
             }
 
-            // Rim lighting - Fresnel Schlick approximation (rimPower^4) for brighter edge glow
+            // === FRESNEL RIM LIGHTING (Neon Bricklayer task) ===
+            // Rim lighting - Fresnel Schlick approximation for brighter edge glow
             let rimPower = 1.0 - NdotV;
-            let rimPower2 = rimPower * rimPower;
-            let rimPower4 = rimPower2 * rimPower2;
-            let rimColor = mix(vColor.rgb, vec3f(1.0), metalMask * fUniforms.metallic);
+            let fresnel = pow(rimPower, fresnelParams.fresnelPower);
+
+            // Gold rim color + intensity (boosted during hard drops)
+            let rimColor = mix(vColor.rgb, vec3f(1.0, 0.85, 0.4), metalMask * fUniforms.metallic); // Warm gold on metal
             let dynamicRim = 5.0 + (fUniforms.movementFlash * 3.0) + (fUniforms.lineClearFlash * 10.0);
-            finalColor += rimColor * rimPower4 * dynamicRim; // JUICE: Enhanced Fresnel Rim Lighting + Dynamic Flash
+            let rimIntensity = (fresnelParams.intensity * dynamicRim) * (1.0 + fresnelParams.hardDropBoost * 2.0);
+
+            let fresnelRim = rimColor * rimIntensity * fresnel;
+            finalColor += fresnelRim; // Additive rim — looks great on gold glass
 
             // Lock tension effect
             let lockPercent = fUniforms.lockPercent;


### PR DESCRIPTION
Implemented the "Neon Bricklayer" visual task by adding a functional Fresnel Rim Lighting effect to the block rendering pipeline, driven dynamically by user actions (like Hard Drops).

---
*PR created automatically by Jules for task [17575474204876902207](https://jules.google.com/task/17575474204876902207) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced rim lighting for gold glass blocks, creating a brighter edge glow based on viewing angle.
  * Hard-drop impacts now briefly intensify the gold flare effect for more noticeable visual feedback.
* **Bug Fixes**
  * Improved consistency of block highlights during movement and impact animations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->