### PR TITLE
Refactor Game Feel Effects to Respect MVC Boundaries

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -247,14 +247,6 @@ export default class Game {
     this.effectCounter++;
     this._gameStateCache.effectFlag = true;
 
-    // Fresnel rim boost during hard drop (Neon Bricklayer task)
-    if (this.view) {
-        (this.view as any).setFresnelBoost?.(1.0);
-    }
-    if (this.view && this.view.visualEffects && this.view.visualEffects.triggerShockwave) {
-        this.view.visualEffects.triggerShockwave([0.5, 0.5], 0.8, 0.4, 0.15, 3.5);
-    }
-
     if (!this.lastDropPos) {
         this.lastDropPos = { x: this.activPiece.x, y: this.activPiece.y };
     } else {
@@ -293,14 +285,6 @@ export default class Game {
     this.effectEvent = 'hardDrop';
     this.effectCounter++;
     this._gameStateCache.effectFlag = true;
-
-    // Fresnel rim boost during hard drop (Neon Bricklayer task)
-    if (this.view) {
-        (this.view as any).setFresnelBoost?.(1.0);
-    }
-    if (this.view && this.view.visualEffects && this.view.visualEffects.triggerShockwave) {
-        this.view.visualEffects.triggerShockwave([0.5, 0.5], 0.8, 0.4, 0.15, 3.5);
-    }
 
     if (!this.lastDropPos) {
         this.lastDropPos = { x: this.activPiece.x, y: this.activPiece.y };

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -29,6 +29,9 @@ export function executeRenderLoop(view: any, dt: number) {
     view._lastEffectCounter = view.state.effectCounter;
     view.shockwaveParamsUniform[0] = 1.0;
     view._hardDropBoostTimer = 0.420; // 420ms
+    if (typeof view.setFresnelBoost === 'function') {
+      view.setFresnelBoost(1.0);
+    }
   }
 
   if (view._hardDropBoostTimer > 0) {


### PR DESCRIPTION
Addressed an architectural concern from `AGENTS.md` and the user's explicit check that `game.ts` shouldn't make direct, hard-coupled function calls manipulating the `viewWebGPU.ts` renderer layer. Moved the triggers (such as `setFresnelBoost`) to the rendering loop governed by existing generic state synchronization properties (`effectCounter`, `effectFlag`), satisfying the framework constraint while keeping visual impact high.

---
*PR created automatically by Jules for task [10206821870626445486](https://jules.google.com/task/10206821870626445486) started by @ford442*