### PR TITLE
Fix WebGPU bind group validation error for border rendering

### DIFF
--- a/src/webgpu/renderers/blockRenderer.ts
+++ b/src/webgpu/renderers/blockRenderer.ts
@@ -27,6 +27,7 @@ type BlockView = {
   uniformBindGroup_ARRAY_border: GPUBindGroup[];
   vertexUniformBuffer_border: GPUBuffer;
   dissolveBuffer: GPUBuffer;
+  fresnelParamsUniform: GPUBuffer;
 };
 
 export class BlockRenderer {
@@ -50,7 +51,7 @@ export class BlockRenderer {
       this.view.blockTexture, this.view.blockSampler,
       this.view.vpMatrix as Float32Array, this.view.currentTheme,
       this.view._f32_3, this.view._f32_4, this.view.MODELMATRIX, this.view.NORMALMATRIX,
-      this.view.dissolveBuffer,
+      this.view.dissolveBuffer, this.view.fresnelParamsUniform,
     );
     this.view.vertexUniformBuffer_border = result.vertexUniformBuffer;
     this.view.uniformBindGroup_ARRAY_border = result.bindGroups;

--- a/src/webgpu/viewPlayfield.ts
+++ b/src/webgpu/viewPlayfield.ts
@@ -268,6 +268,7 @@ export function renderPlayfieldBorder(
   MODELMATRIX: Matrix.mat4,
   NORMALMATRIX: Matrix.mat4,
   dissolveBuffer: GPUBuffer,
+  fresnelParamsUniform: GPUBuffer,
 ): { vertexUniformBuffer: GPUBuffer; bindGroups: GPUBindGroup[] } {
   const state_Border = {
     playfield: [
@@ -294,6 +295,7 @@ export function renderPlayfieldBorder(
           { binding: 2, resource: createBlockTextureBindingView(blockTexture) },
           { binding: 3, resource: blockSampler },
           { binding: 5, resource: { buffer: dissolveBuffer } },
+          { binding: 6, resource: { buffer: fresnelParamsUniform } },
         ],
       });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

WebGPU validation failed at runtime with:

```
Number of entries (5) did not match the expected number of entries (6)
```

The `pbrBlocks` shader expects binding 6 (`fresnelParams` uniform), and block bind groups in `viewWebGPU.ts` already include it. Border bind groups created in `renderPlayfieldBorder` were missing binding 6.

## Fix

- Pass `fresnelParamsUniform` into `renderPlayfieldBorder`
- Add `{ binding: 6, resource: { buffer: fresnelParamsUniform } }` to border bind group entries
- Thread the buffer through `BlockRenderer.refreshBorder()`

## Testing

- `npm test` — 80 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a764098c-0684-4f58-9440-3b26f7d29135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a764098c-0684-4f58-9440-3b26f7d29135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

