### PR TITLE
Refactor WebGPU visual effects to frame-based timers and remove dead code

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -506,27 +506,8 @@ export default class View {
       handleHardDrop(this, x, y, distance, colorIdx);
   }
 
-  setBloomIntensityWithDuration(intensity: number, durationMs: number = 0) {
-    if (!this.bloomSystem) return;
-
-    this.bloomSystem.setParameters({
-      intensity: Math.max(0, intensity),
-    });
-    this.bloomIntensity = intensity;
-
-    if (durationMs > 0) {
-      setTimeout(() => {
-        if (this.bloomSystem) {
-          this.bloomSystem.setParameters({ intensity: 1.0 });
-          this.bloomIntensity = 1.0;
-        }
-      }, durationMs);
-    }
-  }
-
   triggerNeonBloomFlash(strength: number = 1.0) {
-    const peak = 1.8 + strength * 1.2;
-    this.setBloomIntensityWithDuration(peak, 280);
+    this.visualEffects.triggerNeonBloomFlash(strength);
   }
 
   // We added neonBloomFlash to visualEffects for smooth exponential decay per frame.
@@ -535,7 +516,7 @@ export default class View {
     this.visualEffects.triggerNeonBloomFlash(strength);
   }
 
-  triggerBackgroundResonance(intensity: number, durationMs: number = 280) {
+  triggerBackgroundResonance(intensity: number, _durationMs: number = 280) {
     this.visualEffects.triggerBackgroundResonance(intensity);
   }
   renderMainScreen(state: any) { handleRenderMainScreen(this, state); }

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -375,73 +375,12 @@ export class VisualEffects {
         renderLogger.info('Reactive music:', enabled ? 'enabled' : 'disabled');
     }
 
-    triggerReactiveVideo(eventType: 'lineClear' | 'levelUp' | 'tSpin' | 'gameOver', intensity: number, data?: any): void {
-        if (!this.reactiveVideoEnabled) return;
-
-        switch (eventType) {
-            case 'lineClear':
-                // Speed up video on line clears
-                this.videoPlaybackRate = 1.0 + (intensity * 2.0);
-                this.videoElement.playbackRate = Math.min(this.videoPlaybackRate, 4.0);
-                
-                // Glitch effect for big clears
-                if (intensity > 0.5) {
-                    this.triggerGlitch(intensity * 0.5);
-                }
-                break;
-                
-            case 'levelUp':
-                // Reverse video momentarily on level up
-                this.videoElement.playbackRate = -2.0;
-                setTimeout(() => {
-                    if (this.videoElement) {
-                        this.videoElement.playbackRate = 1.0;
-                    }
-                }, 300);
-                this.triggerWarpSurge(1.0);
-                break;
-                
-            case 'tSpin':
-                // Slow motion for T-Spin
-                this.videoElement.playbackRate = 0.3;
-                setTimeout(() => {
-                    if (this.videoElement) {
-                        this.videoElement.playbackRate = 1.0;
-                    }
-                }, 500);
-                break;
-                
-            case 'gameOver':
-                // Freeze frame
-                this.videoElement.pause();
-                break;
-        }
+    triggerReactiveVideo(_eventType: 'lineClear' | 'levelUp' | 'tSpin' | 'gameOver', _intensity: number, _data?: any): void {
+        // Handled by ReactiveVideoBackground
     }
 
-    triggerReactiveMusic(eventType: 'lineClear' | 'levelUp' | 'tSpin' | 'gameOver', intensity: number, data?: any): void {
-        if (!this.reactiveMusicEnabled) return;
-
-        // These are hooks for music system integration
-        // The actual music manipulation would be handled by the SoundManager
-        // We just log for now - the real implementation would emit events
-        switch (eventType) {
-            case 'lineClear':
-                // Music would: pitch shift up, add filter sweep
-                audioLogger.debug('Line clear - intensity:', intensity.toFixed(2));
-                break;
-            case 'levelUp':
-                // Music would: transition to next section, add layer
-                audioLogger.debug('Level up - new section');
-                break;
-            case 'tSpin':
-                // Music would: accent hit, stutter effect
-                audioLogger.debug('T-Spin - accent');
-                break;
-            case 'gameOver':
-                // Music would: slow down, fade out
-                audioLogger.debug('Game over - fade');
-                break;
-        }
+    triggerReactiveMusic(_eventType: 'lineClear' | 'levelUp' | 'tSpin' | 'gameOver', _intensity: number, _data?: any): void {
+        // Handled by SoundManager
     }
 
     triggerWarpSurge(intensity: number = 1.0): void {


### PR DESCRIPTION
Cleaned up WebGPU rendering by replacing frame-lagging `setTimeout` calls with deterministic frame-based effects. Pruned dead code for reactive video and music handling that was previously migrated to `ReactiveVideoBackground` and `SoundManager`. Fixed unused variable TypeScript warnings.

---
*PR created automatically by Jules for task [999298507705252913](https://jules.google.com/task/999298507705252913) started by @ford442*