### PR TITLE
fix: add neonBurst to PostProcessUniforms WGSL struct

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -320,7 +320,8 @@ export default class View {
     hardDropBoost: 0,    // NEW: hard drop shockwave explicitly driven boost
     dangerLevel: 0,      // board height fill ratio 0-1 for danger vignette (postProcess)
     lineClearLaserY: [0, 0, 0, 0] as [number, number, number, number],
-    lineClearLaserIntensity: 0
+    lineClearLaserIntensity: 0,
+    neonBurst: 0,        // hard-drop radial glow/distortion (Neon Bricklayer)
   };
 
   constructor(element: HTMLElement, width: number, height: number, rows: number, coloms: number, nextPieceContext: CanvasRenderingContext2D, holdPieceContext: CanvasRenderingContext2D) {

--- a/src/webgpu/postProcessUniforms.ts
+++ b/src/webgpu/postProcessUniforms.ts
@@ -12,6 +12,7 @@
  * 64-79:  materialAwareBloom, padding(3)
  * 80-95:  aberrationPulse (hard drop)
  * 96-143: reserved (dangerLevel at 96, aberration at 100, levelUpFlash at 104/116, gameOverKaleidoTime at 120 for 2s board kaleidoscope)
+ * 176:    neonBurst (hard-drop radial glow/distortion)
  */
 
 // ============================================================================
@@ -67,7 +68,10 @@ struct PostProcessUniforms {
     lineClearLaserIntensity: f32, // 160
     blackHoleTime: f32,           // 164
     blackHoleCenter: vec2f,       // 168
-    // struct tail-padded to 192B by WGSL
+    neonBurst: f32,               // 176 - hard-drop radial glow/distortion
+    _padTail0: f32,               // 180
+    _padTail1: f32,               // 184
+    _padTail2: f32,               // 188
 };
 `;
 
@@ -122,6 +126,9 @@ export interface PostProcessUniformData {
   lineClearLaserIntensity?: number;
   blackHoleTime?: number;
   blackHoleCenter?: [number, number];
+
+  // Hard-drop neon burst radial glow (Neon Bricklayer)
+  neonBurst?: number;
 }
 
 export class PostProcessUniformManager {
@@ -155,6 +162,7 @@ export class PostProcessUniformManager {
     lineClearLaserIntensity: 0,
     blackHoleTime: 0,
     blackHoleCenter: [0.5, 0.5],
+    neonBurst: 0,
   };
 
   /**
@@ -223,7 +231,8 @@ export class PostProcessUniformManager {
     const bhCenter = (v as any).blackHoleCenter || [0.5, 0.5];
     this.data[42] = bhCenter[0]; // blackHoleCenter @ 168
     this.data[43] = bhCenter[1];
-    // floats 44-47: WGSL struct tail padding (192B)
+    this.data[44] = v.neonBurst ?? 0; // neonBurst @ 176
+    // floats 45-47: WGSL struct tail padding (192B)
 
     return this.data;
   }

--- a/tests/post-process-uniforms.test.ts
+++ b/tests/post-process-uniforms.test.ts
@@ -15,5 +15,6 @@ describe('post-process uniform layout', () => {
     expect(PostProcessUniformsWGSL).toContain('_padLaserAlign: vec2f');
     expect(PostProcessUniformsWGSL).toContain('levelUpFlashColor: vec3f');
     expect(PostProcessUniformsWGSL).toContain('lineClearLaserY: vec4f');
+    expect(PostProcessUniformsWGSL).toContain('neonBurst: f32');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

WGSL shader compilation failed with:

```
error: struct member neonBurst not found
    let burst = uniforms.neonBurst;
```

The post-process shaders (`postProcess.ts`, `enhancedPostProcess.ts`, `materialAwarePostProcess.ts`) referenced `uniforms.neonBurst`, and `viewRenderLoop.ts` was already writing `neonBurst` into `_postProcessParams`, but the shared `PostProcessUniforms` WGSL struct in `postProcessUniforms.ts` never declared the field.

## Fix

- Add `neonBurst: f32` at offset 176 (after `blackHoleCenter`) in `PostProcessUniforms`
- Pack the value in `PostProcessUniformManager.pack()` at float index 44
- Add `neonBurst` to the TypeScript uniform data interface, defaults, and `_postProcessParams`
- Extend the uniform layout test to assert the WGSL struct includes `neonBurst`

Buffer size remains 192 bytes (48 floats).

## Testing

- `npm test` — all 80 tests pass
- `npm run build` — production build succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-197d9b8d-9d65-479c-bb5a-188d6ce43a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197d9b8d-9d65-479c-bb5a-188d6ce43a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new neon burst post-processing effect.
  * Updated rendering settings to include a new adjustable intensity value for hard-drop neon effects.

* **Bug Fixes**
  * Improved post-process data handling so the new effect is included consistently in the rendering pipeline.

* **Tests**
  * Expanded layout verification to cover the new post-process uniform field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->