### PR TITLE
fix: harden high score localStorage against quota errors

### DIFF
--- a/src/game/scoring.ts
+++ b/src/game/scoring.ts
@@ -21,10 +21,73 @@ export interface HighScoreEntry {
   date: string;
 }
 
+/** Compact localStorage representation (minimizes quota usage). */
+interface StoredHighScoreEntry {
+  s: number;
+  l: number;
+  v: number;
+  d: number;
+}
+
+function isQuotaExceededError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'QuotaExceededError' || error.code === 22)
+  );
+}
+
+function normalizeStoredEntry(raw: unknown): HighScoreEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const record = raw as Record<string, unknown>;
+
+  const score =
+    typeof record.score === 'number' ? record.score :
+    typeof record.s === 'number' ? record.s : NaN;
+  const lines =
+    typeof record.lines === 'number' ? record.lines :
+    typeof record.l === 'number' ? record.l : NaN;
+  const level =
+    typeof record.level === 'number' ? record.level :
+    typeof record.v === 'number' ? record.v : NaN;
+
+  if (!Number.isFinite(score) || !Number.isFinite(lines) || !Number.isFinite(level)) {
+    return null;
+  }
+
+  if (score < 0 || lines < 0 || level < 1) return null;
+
+  let date = '';
+  if (typeof record.date === 'string' && record.date.length > 0 && record.date.length <= 32) {
+    date = record.date;
+  } else if (typeof record.d === 'number' && Number.isFinite(record.d)) {
+    date = new Date(record.d).toLocaleDateString();
+  } else {
+    date = new Date().toLocaleDateString();
+  }
+
+  return {
+    score: Math.floor(score),
+    lines: Math.floor(lines),
+    level: Math.floor(level),
+    date,
+  };
+}
+
+function toStoredEntry(entry: HighScoreEntry): StoredHighScoreEntry {
+  const parsed = Date.parse(entry.date);
+  return {
+    s: entry.score,
+    l: entry.lines,
+    v: entry.level,
+    d: Number.isFinite(parsed) ? parsed : Date.now(),
+  };
+}
+
 export class HighScoreManager {
   private readonly STORAGE_KEY = 'tetris_highscores';
   private readonly MAX_ENTRIES = 5;
   private highScores: HighScoreEntry[] = [];
+  private lastSerializedPayload: string | null = null;
 
   constructor() {
     this.loadFromStorage();
@@ -32,25 +95,93 @@ export class HighScoreManager {
 
   private loadFromStorage(): void {
     try {
-      const stored = typeof window !== "undefined" && window.localStorage ? window.localStorage.getItem(this.STORAGE_KEY) : null;
-      if (stored) {
-        this.highScores = JSON.parse(stored);
+      const stored = typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(this.STORAGE_KEY)
+        : null;
+      if (!stored) {
+        this.highScores = [];
+        return;
+      }
+
+      const parsed: unknown = JSON.parse(stored);
+      const source = Array.isArray(parsed) ? parsed : [];
+      const normalized: HighScoreEntry[] = [];
+      for (const item of source) {
+        const entry = normalizeStoredEntry(item);
+        if (entry) normalized.push(entry);
+      }
+
+      normalized.sort((a, b) => b.score - a.score);
+      this.highScores = normalized.slice(0, this.MAX_ENTRIES);
+      this.lastSerializedPayload = this.serialize(this.highScores);
+
+      // Rewrite bloated/legacy payloads with the compact format.
+      if (stored.length > this.lastSerializedPayload.length + 16) {
+        this.saveToStorage();
       }
     } catch (e) {
       gameLogger.warn('Failed to load high scores from localStorage:', e);
       this.highScores = [];
+      this.lastSerializedPayload = null;
     }
   }
 
+  private serialize(entries: HighScoreEntry[]): string {
+    return JSON.stringify(entries.map(toStoredEntry));
+  }
+
+  private writePayload(payload: string): void {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    window.localStorage.setItem(this.STORAGE_KEY, payload);
+    this.lastSerializedPayload = payload;
+  }
+
   private saveToStorage(): void {
+    const payload = this.serialize(this.highScores);
+    if (payload === this.lastSerializedPayload) return;
+
     try {
-      if (typeof window !== "undefined" && window.localStorage) window.localStorage.setItem(this.STORAGE_KEY, JSON.stringify(this.highScores));
+      this.writePayload(payload);
+      return;
+    } catch (e) {
+      if (!isQuotaExceededError(e)) {
+        gameLogger.warn('Failed to save high scores to localStorage:', e);
+        return;
+      }
+    }
+
+    // Quota recovery: drop our key (may be bloated) and retry compact payload.
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.removeItem(this.STORAGE_KEY);
+        this.writePayload(payload);
+        gameLogger.warn('High scores recovered after localStorage quota error.');
+      }
+      return;
+    } catch (e) {
+      if (!isQuotaExceededError(e)) {
+        gameLogger.warn('Failed to save high scores to localStorage:', e);
+        return;
+      }
+    }
+
+    // Last resort: persist only the top score.
+    try {
+      const minimal = this.serialize(this.highScores.slice(0, 1));
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.removeItem(this.STORAGE_KEY);
+        this.writePayload(minimal);
+        this.highScores = this.highScores.slice(0, 1);
+        gameLogger.warn('High scores reduced to top entry due to localStorage quota.');
+      }
     } catch (e) {
       gameLogger.warn('Failed to save high scores to localStorage:', e);
     }
   }
 
   addScore(score: number, lines: number, level: number): boolean {
+    if (score <= 0) return false;
+
     const entry: HighScoreEntry = {
       score,
       lines,
@@ -58,15 +189,18 @@ export class HighScoreManager {
       date: new Date().toLocaleDateString()
     };
 
-    // Check if this score qualifies for top scores
-    if (this.highScores.length < this.MAX_ENTRIES || score > this.highScores[this.highScores.length - 1].score) {
-      this.highScores.push(entry);
-      this.highScores.sort((a, b) => b.score - a.score);
-      this.highScores = this.highScores.slice(0, this.MAX_ENTRIES);
-      this.saveToStorage();
-      return true;
-    }
-    return false;
+    const lowestQualifying =
+      this.highScores.length < this.MAX_ENTRIES
+        ? -1
+        : this.highScores[this.highScores.length - 1].score;
+
+    if (score <= lowestQualifying) return false;
+
+    this.highScores.push(entry);
+    this.highScores.sort((a, b) => b.score - a.score);
+    this.highScores = this.highScores.slice(0, this.MAX_ENTRIES);
+    this.saveToStorage();
+    return true;
   }
 
   getHighScores(): HighScoreEntry[] {
@@ -89,6 +223,7 @@ export class ScoringSystem {
   combo: number = -1; // -1 means no combo
   backToBack: boolean = false;
   private highScoreManager: HighScoreManager;
+  private highScoreSavedThisGame = false;
 
   constructor() {
     this.highScoreManager = new HighScoreManager();
@@ -227,10 +362,13 @@ export class ScoringSystem {
     this.lines = 0;
     this.combo = -1;
     this.backToBack = false;
+    this.highScoreSavedThisGame = false;
   }
 
-  // Save current score to high scores
+  // Save current score to high scores (once per game)
   saveHighScore(): boolean {
+    if (this.highScoreSavedThisGame) return false;
+    this.highScoreSavedThisGame = true;
     return this.highScoreManager.addScore(this.score, this.lines, this.level);
   }
 }

--- a/tests/high-score-storage.test.ts
+++ b/tests/high-score-storage.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HighScoreManager } from '../src/game/scoring.js';
+
+function createStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    key(index: number) {
+      return [...map.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+describe('HighScoreManager localStorage', () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = createStorage();
+    vi.stubGlobal('window', { localStorage: storage });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('stores scores in a compact format', () => {
+    const manager = new HighScoreManager();
+    expect(manager.addScore(12000, 42, 5)).toBe(true);
+
+    const raw = storage.getItem('tetris_highscores');
+    expect(raw).toBeTruthy();
+    expect(raw).toContain('"s":12000');
+    expect(raw).not.toContain('"score"');
+  });
+
+  it('migrates legacy verbose entries and trims to top 5', () => {
+    const legacy = Array.from({ length: 8 }, (_, i) => ({
+      score: (i + 1) * 1000,
+      lines: i,
+      level: 1,
+      date: '1/1/2026',
+    }));
+    storage.setItem('tetris_highscores', JSON.stringify(legacy));
+
+    const manager = new HighScoreManager();
+    const scores = manager.getHighScores();
+
+    expect(scores).toHaveLength(5);
+    expect(scores[0].score).toBe(8000);
+    expect(scores[4].score).toBe(4000);
+  });
+
+  it('recovers from QuotaExceededError by clearing the key and retrying', () => {
+    const manager = new HighScoreManager();
+    const originalSetItem = storage.setItem.bind(storage);
+    let attempts = 0;
+
+    storage.setItem = (key: string, value: string) => {
+      if (key === 'tetris_highscores') {
+        attempts += 1;
+        if (attempts === 1) {
+          const err = new DOMException('quota', 'QuotaExceededError');
+          throw err;
+        }
+      }
+      originalSetItem(key, value);
+    };
+
+    expect(manager.addScore(9000, 10, 2)).toBe(true);
+    expect(attempts).toBe(2);
+    expect(JSON.parse(storage.getItem('tetris_highscores')!)[0].s).toBe(9000);
+  });
+
+  it('ignores zero scores', () => {
+    const manager = new HighScoreManager();
+    expect(manager.addScore(0, 0, 1)).toBe(false);
+    expect(storage.getItem('tetris_highscores')).toBeNull();
+  });
+});

--- a/tests/scoring-save-once.test.ts
+++ b/tests/scoring-save-once.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScoringSystem } from '../src/game/scoring.js';
+
+function createStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    key(index: number) {
+      return [...map.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+describe('ScoringSystem.saveHighScore', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { localStorage: createStorage() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+  it('only attempts persistence once per game', () => {
+    const scoring = new ScoringSystem();
+    scoring.score = 5000;
+    scoring.lines = 20;
+
+    expect(scoring.saveHighScore()).toBe(true);
+    expect(scoring.saveHighScore()).toBe(false);
+  });
+
+  it('allows saving again after reset', () => {
+    const scoring = new ScoringSystem();
+    scoring.score = 3000;
+    scoring.lines = 12;
+
+    expect(scoring.saveHighScore()).toBe(true);
+    scoring.reset();
+    scoring.score = 6000;
+    scoring.lines = 25;
+    expect(scoring.saveHighScore()).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Game over triggered a console warning when persisting high scores:

```
QuotaExceededError: Failed to execute 'setItem' on 'Storage': Setting the value of 'tetris_highscores' exceeded the quota.
```

High score data is small (top 5 only), but the previous implementation had no validation, compact serialization, or recovery when `localStorage` was full or contained a bloated legacy payload.

## Fix

**`HighScoreManager`**
- Validate and normalize entries on load (supports both legacy `{score, lines, level, date}` and compact `{s, l, v, d}` formats)
- Cap to 5 entries after load; auto-rewrite oversized stored payloads
- Serialize with compact keys to reduce storage size
- Skip writes when the serialized payload is unchanged
- On `QuotaExceededError`: remove the key and retry; if still failing, persist only the top score
- Ignore zero scores

**`ScoringSystem`**
- Persist high scores at most once per game (`highScoreSavedThisGame` guard), preventing duplicate writes from multiple game-over code paths

## Testing

- Added `tests/high-score-storage.test.ts` (compact format, legacy migration, quota recovery, zero-score guard)
- Added `tests/scoring-save-once.test.ts` (per-game save guard)
- `npm test` — 86 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-197d9b8d-9d65-479c-bb5a-188d6ce43a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197d9b8d-9d65-479c-bb5a-188d6ce43a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

