### PR TITLE
fix: add binding 4 to post-process bind group

### DIFF
--- a/src/config/renderConfig.ts
+++ b/src/config/renderConfig.ts
@@ -82,6 +82,8 @@ export const PARTICLES_CONFIG = {
 export const UNIFORM_BUFFER_SIZES = {
   /** PostProcessUniforms — vec3/vec4 alignment pads struct to 192B */
   POST_PROCESS: 192,
+  /** shockwaveParamsUniform vec4 — hard-drop boost (binding 4) */
+  SHOCKWAVE_PARAMS: 16,
   /** PBR FragmentUniforms — array tail padding to 224B */
   FRAGMENT: 224,
   /** PBR VertexUniforms — 3×mat4 + vec4 = 208B */

--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -82,6 +82,7 @@ import {
   createSolidFallbackTexture,
   createProceduralFallbackTexture,
   recreateRenderTargets as recreateRenderTargetsImpl,
+  createPostProcessBindGroupEntries,
 } from './webgpu/viewTextures.js';
 import {
   onHardDrop as handleHardDrop,
@@ -178,6 +179,7 @@ export default class View {
   postProcessPipeline!: GPURenderPipeline;
   postProcessBindGroup!: GPUBindGroup;
   postProcessUniformBuffer!: GPUBuffer;
+  shockwaveParamsUniformBuffer!: GPUBuffer;
   offscreenTexture!: GPUTexture;
   depthTexture!: GPUTexture;
   _bloomInputTexture: GPUTexture | null = null;
@@ -797,6 +799,11 @@ export default class View {
     });
 
     this.postProcessUniformBuffer = this.device.createBuffer({ size: UNIFORM_BUFFER_SIZES.POST_PROCESS, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    this.shockwaveParamsUniformBuffer = this.device.createBuffer({
+      size: UNIFORM_BUFFER_SIZES.SHOCKWAVE_PARAMS,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(this.shockwaveParamsUniformBuffer, 0, this.shockwaveParamsUniform);
     this.sampler = this.device.createSampler({ magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge' });
 
     this.offscreenTexture = this.device.createTexture({
@@ -826,12 +833,7 @@ export default class View {
 
     this.postProcessBindGroup = this.device.createBindGroup({
         layout: this.postProcessPipeline.getBindGroupLayout(0),
-        entries: [
-            { binding: 0, resource: { buffer: this.postProcessUniformBuffer } },
-            { binding: 1, resource: this.sampler },
-            { binding: 2, resource: this.offscreenTexture.createView() },
-            { binding: 3, resource: createBlockTextureBindingView(this.blockTexture) }
-        ]
+        entries: createPostProcessBindGroupEntries(this),
     });
 
     // Initialize multi-pass bloom system

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -380,6 +380,10 @@ function updatePostProcessUniforms(view: any, time: number) {
 
   const ppUniforms = postProcessUniforms.pack(view._postProcessParams);
   view.device.queue.writeBuffer(view.postProcessUniformBuffer, 0, ppUniforms);
+
+  if (view.shockwaveParamsUniformBuffer && view.shockwaveParamsUniform) {
+    view.device.queue.writeBuffer(view.shockwaveParamsUniformBuffer, 0, view.shockwaveParamsUniform);
+  }
 }
 
 /**

--- a/src/webgpu/viewTextures.ts
+++ b/src/webgpu/viewTextures.ts
@@ -175,12 +175,7 @@ export async function recreateRenderTargets(view: any) {
   if (view.postProcessPipeline) {
     view.postProcessBindGroup = device.createBindGroup({
       layout: view.postProcessPipeline.getBindGroupLayout(0),
-      entries: [
-        { binding: 0, resource: { buffer: view.postProcessUniformBuffer } },
-        { binding: 1, resource: view.sampler },
-        { binding: 2, resource: view.offscreenTexture.createView() },
-        { binding: 3, resource: createBlockTextureBindingView(view.blockTexture) },
-      ],
+      entries: createPostProcessBindGroupEntries(view),
     });
   }
 
@@ -191,4 +186,23 @@ export async function recreateRenderTargets(view: any) {
     format: presentationFormat,
     usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
   });
+}
+
+export interface PostProcessBindGroupView {
+  postProcessUniformBuffer: GPUBuffer;
+  shockwaveParamsUniformBuffer: GPUBuffer;
+  sampler: GPUSampler;
+  offscreenTexture: GPUTexture;
+  blockTexture: GPUTexture;
+}
+
+/** Bind group entries for post-process shaders (bindings 0–4). */
+export function createPostProcessBindGroupEntries(view: PostProcessBindGroupView): GPUBindGroupEntry[] {
+  return [
+    { binding: 0, resource: { buffer: view.postProcessUniformBuffer } },
+    { binding: 1, resource: view.sampler },
+    { binding: 2, resource: view.offscreenTexture.createView() },
+    { binding: 3, resource: createBlockTextureBindingView(view.blockTexture) },
+    { binding: 4, resource: { buffer: view.shockwaveParamsUniformBuffer } },
+  ];
 }

--- a/src/webgpu/viewUniforms.ts
+++ b/src/webgpu/viewUniforms.ts
@@ -207,6 +207,9 @@ export function updateFrameUniforms(view: any, dt: number, time: number): FrameU
     levelUpFlashIntensity: view.visualEffects.levelUpFlashIntensity || 0,
   });
   device.queue.writeBuffer(view.postProcessUniformBuffer, 0, ppUniforms);
+  if (view.shockwaveParamsUniformBuffer && view.shockwaveParamsUniform) {
+    device.queue.writeBuffer(view.shockwaveParamsUniformBuffer, 0, view.shockwaveParamsUniform);
+  }
 
   return { lockPercent, ghostUVX, ghostUVW, hasActiveParticles, commandEncoder };
 }

--- a/tests/post-process-bindgroup.test.ts
+++ b/tests/post-process-bindgroup.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { PostProcessShaders } from '../src/webgpu/shaders/postProcess.js';
+import { MaterialAwarePostProcessShaders } from '../src/webgpu/shaders/materialAwarePostProcess.js';
+import { createPostProcessBindGroupEntries } from '../src/webgpu/viewTextures.js';
+
+describe('post-process bind group layout', () => {
+  it('shader declares binding 4 for shockwaveParamsUniform', () => {
+    for (const shaders of [PostProcessShaders(), MaterialAwarePostProcessShaders()]) {
+      expect(shaders.fragment).toContain('@binding(4) @group(0) var<uniform> shockwaveParamsUniform');
+    }
+  });
+
+  it('createPostProcessBindGroupEntries supplies bindings 0 through 4', () => {
+    const entries = createPostProcessBindGroupEntries({
+      postProcessUniformBuffer: { } as GPUBuffer,
+      shockwaveParamsUniformBuffer: { } as GPUBuffer,
+      sampler: { } as GPUSampler,
+      offscreenTexture: { createView: () => ({}) } as unknown as GPUTexture,
+      blockTexture: { createView: () => ({}) } as unknown as GPUTexture,
+    });
+
+    expect(entries).toHaveLength(5);
+    expect(entries.map((e) => e.binding)).toEqual([0, 1, 2, 3, 4]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

WebGPU validation failed when creating the post-process bind group:

```
Number of entries (4) did not match the expected number of entries (5)
...
{ binding: 4, ... buffer: { minBindingSize: 16 } }
```

Post-process shaders declare `shockwaveParamsUniform` at **binding 4**, but bind groups only wired bindings 0–3.

## Fix

- Create `shockwaveParamsUniformBuffer` (16-byte vec4 uniform)
- Add **binding 4** to post-process bind groups
- Centralize entries in `createPostProcessBindGroupEntries()` so init and resize paths stay in sync
- Upload `shockwaveParamsUniform` each frame alongside other post-process uniforms

## Testing

- Added `tests/post-process-bindgroup.test.ts`
- `npm test` — 88 tests pass
- `npm run build` — succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-197d9b8d-9d65-479c-bb5a-188d6ce43a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197d9b8d-9d65-479c-bb5a-188d6ce43a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

