### PR TITLE
fix: route neon burst flag and fix block shader uniform bindings

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -22,6 +22,7 @@ export interface GameState {
   effectEvent: string | null;
   effectCounter: number;
   effectFlag?: boolean;
+  neonBurstFlag?: boolean;
   lastDropPos: { x: number, y: number } | null;
   lastDropDistance: number;
   scoreEvent: ScoreEvent | null;
@@ -106,6 +107,7 @@ export default class Game {
     effectEvent: null,
     effectCounter: 0,
     effectFlag: false,
+    neonBurstFlag: false,
     lastDropPos: null,
     lastDropDistance: 0,
     scoreEvent: null,
@@ -217,6 +219,7 @@ export default class Game {
     this._gameStateCache.effectEvent = this.effectEvent;
     this._gameStateCache.effectCounter = this.effectCounter;
     this._gameStateCache.effectFlag = this.effectEvent === 'hardDrop';
+    this._gameStateCache.neonBurstFlag = this.effectEvent === 'hardDrop';
     this._gameStateCache.lastDropPos = this.lastDropPos;
     this._gameStateCache.lastDropDistance = this.lastDropDistance;
     this._gameStateCache.scoreEvent = this.scoreEvent;

--- a/src/webgpu/shaders/main.ts
+++ b/src/webgpu/shaders/main.ts
@@ -77,7 +77,18 @@ export const Shaders = () => {
                 transmission: f32,
                 padding: f32
             };
-            @binding(4) @group(0) var<uniform> materialUniforms : MaterialUniforms;
+                    @binding(4) @group(0) var<uniform> materialUniforms : MaterialUniforms;
+
+        // Dummy bindings to match pbrBlocks layout
+        @binding(5) @group(0) var<storage, read> dissolveField : array<f32, 200>;
+
+        struct FresnelParams {
+            intensity: f32,
+            fresnelPower: f32,
+            hardDropBoost: f32,
+            _pad1: f32,
+        };
+        @binding(6) @group(0) var<uniform> fresnelParams: FresnelParams;
             
             // ============================================================================
             // CONFIGURABLE TEXTURE SAMPLING

--- a/src/webgpu/shaders/premiumBlocks.ts
+++ b/src/webgpu/shaders/premiumBlocks.ts
@@ -304,7 +304,18 @@ export const PremiumBlockShaders = () => {
         };
         @binding(1) @group(0) var<uniform> fUniforms : FragmentUniforms;
         @binding(2) @group(0) var blockTexture : texture_2d<f32>;
-        @binding(3) @group(0) var blockSampler : sampler;
+                @binding(3) @group(0) var blockSampler : sampler;
+
+        // Dummy bindings to match pbrBlocks layout
+        @binding(5) @group(0) var<storage, read> dissolveField : array<f32, 200>;
+
+        struct FresnelParams {
+            intensity: f32,
+            fresnelPower: f32,
+            hardDropBoost: f32,
+            _pad1: f32,
+        };
+        @binding(6) @group(0) var<uniform> fresnelParams: FresnelParams;
 
         ${PBRFunctions}
 

--- a/src/webgpu/shaders/underwaterBlocks.ts
+++ b/src/webgpu/shaders/underwaterBlocks.ts
@@ -207,7 +207,18 @@ export const UnderwaterBlockShaders = () => {
         
         @binding(1) @group(0) var<uniform> fUniforms : FragmentUniforms;
         @binding(2) @group(0) var blockTexture : texture_2d<f32>;
-        @binding(3) @group(0) var blockSampler : sampler;
+                @binding(3) @group(0) var blockSampler : sampler;
+
+        // Dummy bindings to match pbrBlocks layout
+        @binding(5) @group(0) var<storage, read> dissolveField : array<f32, 200>;
+
+        struct FresnelParams {
+            intensity: f32,
+            fresnelPower: f32,
+            hardDropBoost: f32,
+            _pad1: f32,
+        };
+        @binding(6) @group(0) var<uniform> fresnelParams: FresnelParams;
 
         ${UnderwaterPBRFunctions}
         


### PR DESCRIPTION
This commit finalizes the "Neon Bricklayer" visual effect for the 'Neon Burst' hard drop. Previously, `neonBurstFlag` wasn't properly routed through the `GameState` causing the effect to not trigger. Additionally, the WebGPU pipeline had layout validation issues when using different themes because `pbrBlocks.ts` introduced new bindings that were missing in other block shaders. This adds dummy bindings to the other block shaders to fix the pipeline.

---
*PR created automatically by Jules for task [3559498309011716391](https://jules.google.com/task/3559498309011716391) started by @ford442*