### PR TITLE
Neon Bricklayer Game Feel Tuning

### DIFF
--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -6,15 +6,15 @@
 // Input timing (milliseconds)
 export const INPUT_CONFIG = {
   /** Delayed Auto Shift - initial delay before auto-repeat */
-  DAS: 120,
+  DAS: 100,
   /** Auto Repeat Rate - speed of repeated movement */
-  ARR: 10,
+  ARR: 0,
   /** Soft drop speed (sonic drop) */
   SOFT_DROP_SPEED: 1,
   /** Input buffer window for movement (ms) */
-  MOVE_BUFFER_WINDOW: 80,
+  MOVE_BUFFER_WINDOW: 20,
   /** Input buffer window for rotation (ms) - tighter to prevent double-rotations */
-  ROTATE_BUFFER_WINDOW: 60,
+  ROTATE_BUFFER_WINDOW: 20,
 } as const;
 
 // Lock delay mechanics (milliseconds)

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,10 +3,11 @@ import type { IView } from "./view/IView.js";
 import SoundManager from "./sound.js";
 import { TouchControls, TouchAction, addTouchControlStyles } from "./input/touchControls.js";
 import { SubliminalReinforcement } from "./effects/subliminalReinforcement.js";
+import { INPUT_CONFIG } from "./config/gameConfig.js";
 
-const DAS = 100; // Delayed Auto Shift (ms) - Faster for improved responsiveness and top-level play
-const ARR = 0;  // Auto Repeat Rate (ms) - Instant piece movement when holding left or right
-const SOFT_DROP_SPEED = 1; // Sonic Drop: Even faster soft drop for instant tactile feedback
+const DAS = INPUT_CONFIG.DAS; // Delayed Auto Shift (ms) - Faster for improved responsiveness and top-level play
+const ARR = INPUT_CONFIG.ARR;  // Auto Repeat Rate (ms) - Instant piece movement when holding left or right
+const SOFT_DROP_SPEED = INPUT_CONFIG.SOFT_DROP_SPEED; // Sonic Drop: Even faster soft drop for instant tactile feedback
 
 // Logical actions
 type Action = 'left' | 'right' | 'down' | 'rotateCW' | 'rotateCCW' | 'hardDrop' | 'hold';
@@ -49,8 +50,8 @@ export default class Controller {
   bufferedMoveActionTime: number = 0;
   // Split buffer windows for better input precision:
   // Movement is tighter (80ms) and rotation is very tight (60ms) to prevent double-rotations and ensure maximum snappiness
-  readonly MOVE_BUFFER_WINDOW: number = 20; // ms - Tighter, snappier movement
-  readonly JUMP_BUFFER_WINDOW: number = 20; // ms - Strict buffer for jump-like actions to prevent double-rotation
+  readonly MOVE_BUFFER_WINDOW: number = INPUT_CONFIG.MOVE_BUFFER_WINDOW; // ms - Tighter, snappier movement
+  readonly JUMP_BUFFER_WINDOW: number = INPUT_CONFIG.ROTATE_BUFFER_WINDOW; // ms - Strict buffer for jump-like actions to prevent double-rotation
 
   // Mapping from physical key codes to logical actions
   keyMap: { [key: string]: Action } = {

--- a/src/webgpu/postProcessUniforms.ts
+++ b/src/webgpu/postProcessUniforms.ts
@@ -58,8 +58,8 @@ struct PostProcessUniforms {
     dangerLevel: f32,             // 96
     aberrationPulse: f32,         // 100
     hardDropBoost: f32,           // 104
-    neonBurst: f32,               // 108
-    //_padFlashAlign: f32,          // 108
+    _padFlashAlign: f32,          // 108
+
     levelUpFlashColor: vec3f,     // 112
     levelUpFlashIntensity: f32,   // 124
     gameOverKaleidoTime: f32,     // 128
@@ -165,7 +165,6 @@ export class PostProcessUniformManager {
     lineClearLaserIntensity: 0,
     blackHoleTime: 0,
     blackHoleCenter: [0.5, 0.5],
-    neonBurst: 0,
   };
 
   /**
@@ -213,7 +212,7 @@ export class PostProcessUniformManager {
     this.data[24] = (v as any).dangerLevel || 0;
     this.data[25] = (v as any).aberrationPulse || 0;
     this.data[26] = (v as any).hardDropBoost || 0; // hardDropBoost @ 104
-    this.data[27] = (v as any).neonBurst || 0; // neonBurst @ 108
+    this.data[27] = 0; // removed duplicate neonBurst @ 108
     const flashCol = (v as any).levelUpFlashColor || [0, 0, 0];
     this.data[28] = flashCol[0] || 0; // levelUpFlashColor @ 112
     this.data[29] = flashCol[1] || 0;


### PR DESCRIPTION
The Neon Bricklayer requested Game Feel Tuning via DAS/ARR modifications and visual upgrades. The required visual WebGPU updates (shockwave, bloom, particle hits) were largely already in the codebase, however DAS/ARR settings were out-of-sync and a duplicate uniform struct key caused build/test failures. This commit centralizes the control mechanics into `gameConfig.ts` with the exact tighter values required (DAS=100, ARR=0) and resolves the failing tests by fixing the WebGPU uniform mapping.

---
*PR created automatically by Jules for task [18282648983803635326](https://jules.google.com/task/18282648983803635326) started by @ford442*