### PR TITLE
feat: Add Music Reactive Chromatic Aberration

### DIFF
--- a/public/assets/video/manifest.json
+++ b/public/assets/video/manifest.json
@@ -6,5 +6,5 @@
     "bg3.mp4"
   ],
   "generated": false,
-  "builtAt": "2026-07-16T00:14:45.975Z"
+  "builtAt": "2026-07-18T09:25:25.175Z"
 }

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -67,6 +67,9 @@ export class VisualEffects {
     // (separate from general aberrationIntensity; fed to u_aberrationPulse uniform in enhanced post-process)
     hardDropAberrationPulse: number = 0;
 
+    // Music/Event driven base chromatic intensity (exponential decay)
+    baseChromaticIntensity: number = 0;
+
     // Grid radial ripple from last lock (epicenter + 0..0.5s wave time for 500ms outward fade on grid lines)
     gridRippleCenter: [number, number] = [0.0, 0.0];
     gridRippleTime: number = 0.0;
@@ -178,6 +181,10 @@ export class VisualEffects {
         this.hardDropAberrationPulse *= 1.0 / (1.0 + dt / 0.08);
         if (this.hardDropAberrationPulse < 0.005) this.hardDropAberrationPulse = 0;
 
+        // Base chromatic aberration intensity decay
+        this.baseChromaticIntensity *= Math.exp(-dt * 3.0);
+        if (this.baseChromaticIntensity < 0.005) this.baseChromaticIntensity = 0;
+
         // Grid ripple decay (age the wave; render loop / shader handles visual fade at 500ms)
         if (this.gridRippleTime > 0.0) {
             this.gridRippleTime += dt;
@@ -287,6 +294,14 @@ export class VisualEffects {
     triggerHardDropAberrationPulse(strength: number = 1.0): void {
         if (this.reducedMotion) return;
         this.hardDropAberrationPulse = Math.max(this.hardDropAberrationPulse, strength);
+    }
+
+    /**
+     * Trigger a spike in base chromatic intensity (e.g. from line clears, combo, or hard drop)
+     */
+    triggerChromaticSpike(strength: number = 1.0): void {
+        if (this.reducedMotion) return;
+        this.baseChromaticIntensity = Math.min(3.0, this.baseChromaticIntensity + strength);
     }
 
     /**

--- a/src/webgpu/postProcessUniforms.ts
+++ b/src/webgpu/postProcessUniforms.ts
@@ -71,7 +71,7 @@ struct PostProcessUniforms {
     blackHoleCenter: vec2f,       // 168
     neonBurst: f32,               // 176 - hard-drop radial glow/distortion
     saturationBoost: f32,         // 180 - Line Clear Escalation
-    _padTail1: f32,               // 184
+    chromaticIntensity: f32,      // 184 - Music/Event driven chromatic aberration
     _padTail2: f32,               // 188
 };
 `;
@@ -131,6 +131,9 @@ export interface PostProcessUniformData {
 
   // Hard-drop neon burst radial glow (Neon Bricklayer)
   saturationBoost?: number;
+
+  // Music/Event driven chromatic aberration
+  chromaticIntensity?: number;
 }
 
 export class PostProcessUniformManager {
@@ -166,6 +169,7 @@ export class PostProcessUniformManager {
     blackHoleTime: 0,
     blackHoleCenter: [0.5, 0.5],
     saturationBoost: 0,
+    chromaticIntensity: 0,
   };
 
   /**
@@ -236,7 +240,8 @@ export class PostProcessUniformManager {
     this.data[43] = bhCenter[1];
     this.data[44] = v.neonBurst ?? 0; // neonBurst @ 176
     this.data[45] = v.saturationBoost ?? 0; // saturationBoost @ 180
-    // floats 46-47: WGSL struct tail padding (192B)
+    this.data[46] = v.chromaticIntensity ?? 0; // chromaticIntensity @ 184
+    // floats 47: WGSL struct tail padding (192B)
 
     return this.data;
   }

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -287,6 +287,10 @@ export const EnhancedPostProcessShaders = () => {
             let horizOffset = totalAberration + glitchOffset + shockwaveAberration;
             let vertAberration = totalAberration * (uv.y - 0.5) * 0.2 + (shockwaveAberration * 0.5);
 
+            // NEON BRICKLAYER: Music/Event driven chromatic aberration
+            let chromaticMusicOffset = uniforms.chromaticIntensity * 0.02 * (uv.y - 0.5);
+            let chromaticMusicHoriz = uniforms.chromaticIntensity * 0.015;
+
             // NEW: Hard-drop triggered short-lived chromatic aberration spike (u_aberrationPulse)
             // 300ms exp decay (CPU side), separate per-channel RGB offsets for a sharp "spike" at impact.
             // Positive/negative splits create classic red/cyan fringing that peaks then fades.
@@ -296,9 +300,9 @@ export const EnhancedPostProcessShaders = () => {
             let pulseB = pulse * -0.018;
 
             let baseSample = textureSample(myTexture, mySampler, finalUV);
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR, vertAberration + pulseG * 0.6)).r;
+            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset)).r;
             var g = baseSample.g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB, vertAberration + pulseR * 0.4)).b;
+            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset)).b;
             var color = vec3<f32>(r, g, b);
 
             // Add the shattered glass overlay into the final color

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -337,6 +337,10 @@ export const MaterialAwarePostProcessShaders = () => {
             let horizOffset = totalAberration + glitchOffset + shockwaveAberration;
             let vertAberration = totalAberration * (uv.y - 0.5) * 0.2 + (shockwaveAberration * 0.5);
 
+            // NEON BRICKLAYER: Music/Event driven chromatic aberration
+            let chromaticMusicOffset = uniforms.chromaticIntensity * 0.02 * (uv.y - 0.5);
+            let chromaticMusicHoriz = uniforms.chromaticIntensity * 0.015;
+
             // NEW: Hard-drop triggered short-lived chromatic aberration spike (u_aberrationPulse)
             // 300ms exp decay (CPU side), separate per-channel RGB offsets for a sharp "spike" at impact.
             // Positive/negative splits create classic red/cyan fringing that peaks then fades.
@@ -346,9 +350,9 @@ export const MaterialAwarePostProcessShaders = () => {
             let pulseB = pulse * -0.018;
 
             let baseSample = textureSample(myTexture, mySampler, finalUV);
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR, vertAberration + pulseG * 0.6)).r;
+            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset)).r;
             var g = baseSample.g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB, vertAberration + pulseR * 0.4)).b;
+            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset)).b;
             var color = vec3<f32>(r, g, b);
 
             // Add the shattered glass overlay into the final color

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -191,6 +191,10 @@ export const PostProcessShaders = () => {
             let horizOffset = totalAberration + glitchOffset + shockwaveAberration;
             let vertAberration = totalAberration * (uv.y - 0.5) * 0.2 + (shockwaveAberration * 0.5);
 
+            // NEON BRICKLAYER: Music/Event driven chromatic aberration
+            let chromaticMusicOffset = uniforms.chromaticIntensity * 0.02 * (uv.y - 0.5);
+            let chromaticMusicHoriz = uniforms.chromaticIntensity * 0.015;
+
             // NEW: Hard-drop triggered short-lived chromatic aberration spike (u_aberrationPulse)
             // 300ms exp decay (CPU side), separate per-channel RGB offsets for a sharp "spike" at impact.
             // Positive/negative splits create classic red/cyan fringing that peaks then fades.
@@ -200,9 +204,9 @@ export const PostProcessShaders = () => {
             let pulseB = pulse * -0.018;
 
             let baseSample = textureSample(myTexture, mySampler, finalUV);
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR, vertAberration + pulseG * 0.6)).r;
+            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset)).r;
             var g = baseSample.g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB, vertAberration + pulseR * 0.4)).b;
+            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset)).b;
             let a = baseSample.a;
 
             // Bloom-ish boost (optimized 5-tap tent filter)

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -58,6 +58,7 @@ export function triggerComboOverdrive(view: ViewEventHost, combo: number): void 
   view.visualEffects.triggerSaturationBoost(1.5 + combo * 0.5);
   view.visualEffects.triggerSaturationBoost(1.5 + combo * 0.5);
   view.visualEffects.triggerBlackHole([0.5, 0.5]); // short duration pull
+  view.visualEffects.triggerChromaticSpike(2.0); // NEON BRICKLAYER
 }
 
 export function triggerEnergyWave(view: ViewEventHost, combo: number): void {
@@ -66,6 +67,7 @@ export function triggerEnergyWave(view: ViewEventHost, combo: number): void {
   view.visualEffects.triggerSaturationBoost(0.8 + combo * 0.2);
   view.visualEffects.triggerAberration(1.5 + combo * 0.3);
   view.visualEffects.triggerHardDropAberrationPulse(1.5);
+  view.visualEffects.triggerChromaticSpike(1.5); // NEON BRICKLAYER
 }
 
 export function showFloatingComboText(view: ViewEventHost, combo: number): void {
@@ -176,6 +178,7 @@ export function onLineClear(view: ViewEventHost, lines: number[], tSpin: boolean
   // If it's a Tetris or T-Spin, heavily distort the background hyperspace tunnel.
   if (lines.length >= 4 || tSpin) {
     view.visualEffects.triggerWarpSurge(2.0 + lines.length * 0.5);
+    view.visualEffects.triggerChromaticSpike(1.5 + lines.length * 0.2); // NEON BRICKLAYER
   }
 
   lines.forEach((y: number) => {

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -355,7 +355,7 @@ function updatePostProcessUniforms(view: any, time: number) {
 
   view._postProcessParams.neonBurst = view.neonBurstUniform ? view.neonBurstUniform[0] : 0.0;
   view._postProcessParams.saturationBoost = view.visualEffects.saturationBoost || 0.0;
-  view._postProcessParams.saturationBoost = view.visualEffects.saturationBoost || 0.0;
+  view._postProcessParams.chromaticIntensity = view.visualEffects.baseChromaticIntensity || 0.0;
 
   // Compute board height fill ratio (0-1) for contracting danger vignette.
   // Uses highest occupied row (top = low index). No allocations in hot path.
@@ -413,6 +413,9 @@ function updatePostProcessUniforms(view: any, time: number) {
     view.device.queue.writeBuffer(view.fragmentUniformBuffer, 188, view._f32_1);
     view._f32_1[0] = bands.treble || 0;
     view.device.queue.writeBuffer(view.fragmentUniformBuffer, 192, view._f32_1);
+
+    // NEON BRICKLAYER: Add music reactivity to chromatic aberration
+    view._postProcessParams.chromaticIntensity += (bands.bass || 0.0) * 0.8 + (bands.mid || 0.0) * 0.3;
   }
 
   // Drive border glow (per-side pulsing) via the helper in viewPlayfield (uniforms + shader primary).


### PR DESCRIPTION
Enhances the post-processing layer to incorporate a dynamic music and event-driven chromatic aberration effect. This amplifies the "juice" during gameplay by creating satisfying screen-tearing chromatic spikes during hard drops and major line clears, while establishing a subtle continuous response to the background music's bass and mid frequencies.

---
*PR created automatically by Jules for task [5055653241588524767](https://jules.google.com/task/5055653241588524767) started by @ford442*