### PR TITLE
feat(vfx): trigger Black Hole effect on Tetris line clear

### DIFF
--- a/public/assets/video/manifest.json
+++ b/public/assets/video/manifest.json
@@ -6,5 +6,5 @@
     "bg3.mp4"
   ],
   "generated": false,
-  "builtAt": "2026-07-18T13:58:11.560Z"
+  "builtAt": "2026-07-19T00:39:39.774Z"
 }

--- a/public/assets/video/manifest.json
+++ b/public/assets/video/manifest.json
@@ -6,5 +6,5 @@
     "bg3.mp4"
   ],
   "generated": false,
-  "builtAt": "2026-07-19T00:39:39.774Z"
+  "builtAt": "2026-07-19T00:54:54.609Z"
 }

--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -296,6 +296,8 @@ export default class View implements IView, ViewEventHost, WebGPUViewHost {
     useGlitch: 0,
     shockwaveCenter: [0, 0] as [number, number],
     shockwaveTime: 0,
+    blackHoleTime: 0,
+    blackHoleCenter: [0, 0] as [number, number],
     shockwaveParams: [0, 0, 0, 0] as [number, number, number, number],
     level: 0,
     warpSurge: 0,

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -176,7 +176,7 @@ export const EnhancedPostProcessShaders = () => {
                 let bhDist = length(bhDiff);
 
                 // Exponential radius shrink as it decays
-                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+                let bhRadius = 0.6 * (1.0 - pow(bhTime, 0.4));
 
                 if (bhDist < bhRadius && bhDist > 0.0) {
                     let angle = atan2(bhDiff.y, bhDiff.x);
@@ -414,6 +414,23 @@ export const EnhancedPostProcessShaders = () => {
             }
 
             // Canvas uses alphaMode: 'premultiplied' — RGB must be scaled by alpha.
+
+            // Darken the center of the black hole
+            if (uniforms.blackHoleTime > 0.001) {
+                let bhCenter = uniforms.blackHoleCenter;
+                let bhTime = uniforms.blackHoleTime;
+                let bhDiff = uv - bhCenter;
+                let bhDist = length(bhDiff);
+                let bhRadius = 0.6 * (1.0 - pow(bhTime, 0.4));
+                if (bhDist < bhRadius) {
+                    let darkFactor = smoothstep(0.0, bhRadius * 0.5, bhDist);
+                    color *= darkFactor;
+                    // Event horizon cyan glow
+                    let ring = smoothstep(bhRadius * 0.8, bhRadius, bhDist) * (1.0 - smoothstep(bhRadius, bhRadius * 1.2, bhDist));
+                    color += vec3<f32>(0.2, 0.8, 1.0) * ring * 2.0 * (1.0 - bhTime);
+                }
+            }
+
             return vec4<f32>(color * sampledAlpha, sampledAlpha);
         }
     `;

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -226,7 +226,7 @@ export const MaterialAwarePostProcessShaders = () => {
                 let bhDist = length(bhDiff);
 
                 // Exponential radius shrink as it decays
-                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+                let bhRadius = 0.6 * (1.0 - pow(bhTime, 0.4));
 
                 if (bhDist < bhRadius && bhDist > 0.0) {
                     let angle = atan2(bhDiff.y, bhDiff.x);
@@ -465,6 +465,23 @@ export const MaterialAwarePostProcessShaders = () => {
             }
 
             // Canvas uses alphaMode: 'premultiplied' — RGB must be scaled by alpha.
+
+            // Darken the center of the black hole
+            if (uniforms.blackHoleTime > 0.001) {
+                let bhCenter = uniforms.blackHoleCenter;
+                let bhTime = uniforms.blackHoleTime;
+                let bhDiff = uv - bhCenter;
+                let bhDist = length(bhDiff);
+                let bhRadius = 0.6 * (1.0 - pow(bhTime, 0.4));
+                if (bhDist < bhRadius) {
+                    let darkFactor = smoothstep(0.0, bhRadius * 0.5, bhDist);
+                    color *= darkFactor;
+                    // Event horizon cyan glow
+                    let ring = smoothstep(bhRadius * 0.8, bhRadius, bhDist) * (1.0 - smoothstep(bhRadius, bhRadius * 1.2, bhDist));
+                    color += vec3<f32>(0.2, 0.8, 1.0) * ring * 2.0 * (1.0 - bhTime);
+                }
+            }
+
             return vec4<f32>(color * sampledAlpha, sampledAlpha);
         }
     `;

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -48,7 +48,7 @@ export const PostProcessShaders = () => {
                 let bhDist = length(bhDiff);
 
                 // Exponential radius shrink as it decays
-                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+                let bhRadius = 0.6 * (1.0 - pow(bhTime, 0.4));
 
                 if (bhDist < bhRadius && bhDist > 0.0) {
                     let angle = atan2(bhDiff.y, bhDiff.x);
@@ -240,7 +240,7 @@ export const PostProcessShaders = () => {
                 let bhTime = uniforms.blackHoleTime;
                 let bhDiff = uv - bhCenter;
                 let bhDist = length(bhDiff);
-                let bhRadius = 0.5 * (1.0 - pow(bhTime, 0.5));
+                let bhRadius = 0.6 * (1.0 - pow(bhTime, 0.4));
                 if (bhDist < bhRadius) {
                     let darkFactor = smoothstep(0.0, bhRadius * 0.5, bhDist);
                     color *= darkFactor;

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -327,8 +327,15 @@ function updatePostProcessUniforms(view: WebGPUViewHost, time: number) {
   view._postProcessParams.shockwaveCenter[1] = view.visualEffects.shockwaveCenter[1];
   view._postProcessParams.shockwaveTime = shockwaveActive ? view.visualEffects.shockwaveTimer : 0;
   view._postProcessParams.blackHoleTime = view.visualEffects.blackHoleTime;
-  view._postProcessParams.blackHoleCenter[0] = view.visualEffects.blackHoleCenter[0];
-  view._postProcessParams.blackHoleCenter[1] = view.visualEffects.blackHoleCenter[1];
+  if (view._postProcessParams.blackHoleCenter) {
+    if (view.visualEffects.blackHoleCenter && view.visualEffects.blackHoleCenter.length >= 2) {
+      view._postProcessParams.blackHoleCenter[0] = view.visualEffects.blackHoleCenter[0];
+      view._postProcessParams.blackHoleCenter[1] = view.visualEffects.blackHoleCenter[1];
+    } else {
+      view._postProcessParams.blackHoleCenter[0] = 0.5;
+      view._postProcessParams.blackHoleCenter[1] = 0.5;
+    }
+  }
   
   const currentShockwaveParams = view.visualEffects.getShockwaveParams();
   view._postProcessParams.shockwaveParams[0] = currentShockwaveParams[0];

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -326,6 +326,9 @@ function updatePostProcessUniforms(view: WebGPUViewHost, time: number) {
   view._postProcessParams.shockwaveCenter[0] = view.visualEffects.shockwaveCenter[0];
   view._postProcessParams.shockwaveCenter[1] = view.visualEffects.shockwaveCenter[1];
   view._postProcessParams.shockwaveTime = shockwaveActive ? view.visualEffects.shockwaveTimer : 0;
+  view._postProcessParams.blackHoleTime = view.visualEffects.blackHoleTime;
+  view._postProcessParams.blackHoleCenter[0] = view.visualEffects.blackHoleCenter[0];
+  view._postProcessParams.blackHoleCenter[1] = view.visualEffects.blackHoleCenter[1];
   
   const currentShockwaveParams = view.visualEffects.getShockwaveParams();
   view._postProcessParams.shockwaveParams[0] = currentShockwaveParams[0];


### PR DESCRIPTION
This PR adds a visual "Black Hole" effect to Tetris line clears to enhance the game feel and visual spectacle ("JUICE").

1.  **Event Integration**: Modified `src/webgpu/viewGameEvents.ts` to detect 4-line clears (Tetrises) and dynamically calculate the vertical midpoint of the cleared lines. This center point is then used to trigger the Black Hole effect via `view.visualEffects.triggerBlackHole([0.5, uvY])`.
2.  **Uniform Passing**: Updated `src/viewWebGPU.ts` and `src/webgpu/viewRenderLoop.ts` to correctly pass `blackHoleTime` and `blackHoleCenter` from `visualEffects` down into `_postProcessParams`.
3.  **Shader Polish**: Tweaked the fragment shaders (`src/webgpu/shaders/postProcess.ts`, `src/webgpu/shaders/materialAwarePostProcess.ts`, `src/webgpu/shaders/enhancedPostProcess.ts`) to adjust the radius decay curve and ensure the center of the black hole explicitly darkens with a prominent event horizon cyan glow.

---
*PR created automatically by Jules for task [2568512088948487626](https://jules.google.com/task/2568512088948487626) started by @ford442*