### PR TITLE
Fail deploy preflight when DEPLOY_TOKEN is missing

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -89,7 +89,10 @@ def preflight(build_path: Path) -> bool:
         else:
             print(f"  ✓ {rel} ({asset.stat().st_size / 1024:.1f} KB)")
     if not DEPLOY_TOKEN:
-        print('  ⚠ DEPLOY_TOKEN is not set — upload may be rejected by the deploy API.')
+        print('  ✗ DEPLOY_TOKEN is not set — upload will be rejected (403).')
+        ok = False
+    else:
+        print('  ✓ DEPLOY_TOKEN is set')
     print()
     return ok
 
@@ -174,7 +177,13 @@ def main():
         sys.exit(1)
 
     if not preflight(build_path):
-        print('ERROR: Preflight failed — fix the build before deploying.')
+        if not DEPLOY_TOKEN:
+            print('ERROR: DEPLOY_TOKEN is required for Contabo deploy uploads.')
+            print('Set it in your shell or Cloud Agent environment secrets, then retry:')
+            print('  export DEPLOY_TOKEN="<token-from-vps-env>"')
+            print('  python deploy.py')
+        else:
+            print('ERROR: Preflight failed — fix the build before deploying.')
         sys.exit(1)
 
     try:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deployment to Contabo fails with `403: Invalid or missing X-Deploy-Token` when `DEPLOY_TOKEN` is not set. The script previously warned about this but still built a ~14 MB zip and attempted upload.

This change treats a missing token as a hard preflight failure and prints actionable setup instructions before exiting.

## Changes

- Mark missing `DEPLOY_TOKEN` as a preflight error (not just a warning)
- Exit before zip/upload with instructions to set the secret via `export` or Cloud Agent environment secrets
- Show `✓ DEPLOY_TOKEN is set` when the token is present

## How to deploy (unchanged)

```bash
npm run build:all
export DEPLOY_TOKEN="<token-from-vps-env>"
python3 deploy.py
```

The token value must come from the VPS deploy service configuration — it is not stored in this repository.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32025c52-cb7d-410d-8d58-806b957b723a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32025c52-cb7d-410d-8d58-806b957b723a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

