### PR TITLE
fix(webgpu): repair main pipeline shader compile errors

### DIFF
--- a/src/webgpu/shaders/block/blockShader.ts
+++ b/src/webgpu/shaders/block/blockShader.ts
@@ -30,10 +30,6 @@ export function createBlockShaders(): BlockShaderSources {
 
         ${textureSamplingCode}
 
-        struct MaterialProperties {
-           metallic: f32,
-        };
-
         ${BLOCK_FRAGMENT_MAIN_WGSL}
     `;
 

--- a/src/webgpu/shaders/block/fragmentMain.wgsl.ts
+++ b/src/webgpu/shaders/block/fragmentMain.wgsl.ts
@@ -463,22 +463,6 @@ export const BLOCK_FRAGMENT_MAIN_WGSL = `
                 finalColor += vec3f(borderBoost);
             }
 
-            // NEW: Apply particle-material interaction
-            let matType = fUniforms.particleMaterialType;
-            let particleIntensity = fUniforms.particleIntensity;
-            if (matType > 0u && particleIntensity > 0.0) {
-                // Determine interaction color based on material
-                var interactionColor = vec3f(1.0);
-                if (matType == 2u) { interactionColor = vec3f(1.0, 0.84, 0.0); } // Gold
-                else if (matType == 3u) { interactionColor = vec3f(0.9, 0.95, 1.0); } // Chrome
-                else if (matType == 4u) { interactionColor = vec3f(0.0, 1.0, 1.0); } // Cyber
-
-                var dummyMat: MaterialProperties;
-                dummyMat.metallic = fUniforms.metallic;
-
-                finalColor = applyMaterialParticleInteraction(dummyMat, finalColor, N, V, L, matType, particleIntensity, interactionColor);
-            }
-
             finalColor = clamp(finalColor, vec3f(0.0), vec3f(1.0));
 
             // === GPU CLEAR-DISSOLVE GLOW ===

--- a/tests/shader-module-structure.test.ts
+++ b/tests/shader-module-structure.test.ts
@@ -41,9 +41,11 @@ describe('authoritative block shader structure', () => {
     expect(fragment).toContain('struct FragmentUniforms');
     expect(fragment).toContain('dissolveField');
     expect(fragment).toContain('fresnelParams');
-    // Particle interaction injected once (no duplicate WGSL paste)
-    const interactionMarker = 'applyMaterialParticleInteraction';
-    expect(fragment.split(interactionMarker).length - 1).toBe(1);
+    // Particle interaction injected once (no duplicate WGSL paste or duplicate locals)
+    const interactionMarker = 'applyParticleInteraction';
+    expect(fragment.split(interactionMarker).length - 1).toBe(2); // fn def + one call site
+    expect(fragment.split('let particleIntensity').length - 1).toBe(1);
+    expect(fragment).not.toContain('applyMaterialParticleInteraction');
   });
 
   it('keeps CPU uniform buffer size aligned with WGSL struct', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Starting the app fails with WebGPU validation errors:

```
[Invalid RenderPipeline "main pipeline"] is invalid due to a previous error.
```

The root cause is WGSL compilation failure in the block fragment shader, not a bind-group or device issue.

## Root cause

The production block shader (`fragmentMain.wgsl.ts`) had two compile-breaking issues:

1. **Undefined function call** — `applyMaterialParticleInteraction()` was invoked, but `blockShader.ts` only injects WGSL from `shaders/particleMaterialInteraction.ts`, which defines `applyParticleInteraction()` instead.
2. **Duplicate local** — `particleIntensity` was declared twice in the same `main()` scope (lines 384 and 468).

Either issue alone invalidates the `"main pipeline"` at creation time.

## Fix

- Remove the duplicate legacy particle-interaction block that called the undefined function.
- Keep the active `applyParticleInteraction` path (uses `materialType` + mask inference).
- Remove the now-unused `MaterialProperties` struct from the shader factory.
- Add regression checks in `shader-module-structure.test.ts` for single `particleIntensity` declaration and no stale `applyMaterialParticleInteraction` reference.

## Verification

- `npm test` — 192 tests pass
- Composed shader now has `applyParticleInteraction` defined + used, zero `applyMaterialParticleInteraction` references, and one `particleIntensity` declaration.

## Notes

The `powerPreference` and `willReadFrequently` console messages in the original report are benign warnings unrelated to this failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-922fca04-cc17-4bfd-a1c8-2a2c873cc6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-922fca04-cc17-4bfd-a1c8-2a2c873cc6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

