### PR TITLE
Optimize WebGPU post-process shaders, rendering thresholds, and input timing

### DIFF
--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -12,9 +12,9 @@ export const INPUT_CONFIG = {
   /** Soft drop speed (sonic drop) */
   SOFT_DROP_SPEED: 1,
   /** Input buffer window for movement (ms) */
-  MOVE_BUFFER_WINDOW: 20,
+  MOVE_BUFFER_WINDOW: 40,
   /** Input buffer window for rotation (ms) - tighter to prevent double-rotations */
-  ROTATE_BUFFER_WINDOW: 20,
+  ROTATE_BUFFER_WINDOW: 40,
 } as const;
 
 // Lock delay mechanics (milliseconds)

--- a/src/game/lockDelay.ts
+++ b/src/game/lockDelay.ts
@@ -54,7 +54,7 @@ export function handleMoveReset(host: LockDelayHost): void {
       host.lockResets++;
     }
   } else {
-    host.lockTimer = -150;
+    host.lockTimer = -200;
     host.lockResets = 0;
   }
 }

--- a/src/webgpu/blockTexture.ts
+++ b/src/webgpu/blockTexture.ts
@@ -193,12 +193,12 @@ export const DEFAULT_BLOCK_TEXTURE_CONFIG: BlockTextureConfig = {
   subregionHeight: 0.446,
   subregionInset: 0.04,
   materialDetectionMode: 'color_signal',
-  metalThresholdLow: 0.80,
+  metalThresholdLow: 0.75,
   metalThresholdHigh: 1.20,
   useProceduralFallback: true,
   maskChannel: 'auto',
   // Reference curve matching block.png gold frame + crystal interior.
-  authoredGlassMin: 0.38,
+  authoredGlassMin: 0.30,
   authoredGlassMax: 0.78,
   authoredGlassFresnelPower: 2.0,
 
@@ -215,10 +215,10 @@ export const SINGLE_TILE_TEXTURE_CONFIG: BlockTextureConfig = {
   url: 'block.png',
   samplingMode: 'single',
   materialDetectionMode: 'luminance',
-  metalThresholdLow: 0.45,
+  metalThresholdLow: 0.40,
   metalThresholdHigh: 0.55,
   useProceduralFallback: true,
-  authoredGlassMin: 0.38,
+  authoredGlassMin: 0.30,
   authoredGlassMax: 0.78,
   authoredGlassFresnelPower: 2.0,
 
@@ -289,7 +289,7 @@ export function createBlockTextureSamplerDescriptor(): GPUSamplerDescriptor {
     addressModeV: 'clamp-to-edge',
     lodMinClamp: 0,
     lodMaxClamp: BLOCK_TEXTURE_MAX_LOD,
-    maxAnisotropy: 16,
+    maxAnisotropy: 4,
   };
 }
 

--- a/src/webgpu/geometry.ts
+++ b/src/webgpu/geometry.ts
@@ -21,7 +21,7 @@ export const CubeData = () => {
 
   // Keep the face UVs normalized because the shader now samples
   // a single tile from the texture atlas for each block face.
-  const textureScale = 0.98; // Zoom in to avoid blurry tile edges
+  const textureScale = 0.99; // Zoom in to avoid blurry tile edges
 
   const pushVertex = (x: number, y: number, z: number, uAxis: string, vAxis: string, uDir: number, vDir: number) => {
     // 1. Clamp to inner box

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -36,10 +36,10 @@ export const EnhancedPostProcessShaders = () => {
             let texelSize = 1.0 / vec2<f32>(uniforms.screenWidth, uniforms.screenHeight);
 
             // Sample neighboring pixels (all sampling done unconditionally)
-            let nw = textureSample(myTexture, mySampler, uv + vec2<f32>(-texelSize.x, -texelSize.y)).rgb;
-            let ne = textureSample(myTexture, mySampler, uv + vec2<f32>( texelSize.x, -texelSize.y)).rgb;
-            let sw = textureSample(myTexture, mySampler, uv + vec2<f32>(-texelSize.x,  texelSize.y)).rgb;
-            let se = textureSample(myTexture, mySampler, uv + vec2<f32>( texelSize.x,  texelSize.y)).rgb;
+            let nw = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-texelSize.x, -texelSize.y), 0.0).rgb;
+            let ne = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( texelSize.x, -texelSize.y), 0.0).rgb;
+            let sw = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-texelSize.x,  texelSize.y), 0.0).rgb;
+            let se = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( texelSize.x,  texelSize.y), 0.0).rgb;
 
             // Convert to luminance
             let lumaM = dot(texColor, vec3<f32>(0.299, 0.587, 0.114));
@@ -65,12 +65,12 @@ export const EnhancedPostProcessShaders = () => {
 
             // Sample along gradient (unconditional - avoids non-uniform control flow)
             let rgbA = 0.5 * (
-                textureSample(myTexture, mySampler, uv + dir * (1.0 / 3.0 - 0.5)).rgb +
-                textureSample(myTexture, mySampler, uv + dir * (2.0 / 3.0 - 0.5)).rgb
+                textureSampleLevel(myTexture, mySampler, uv + dir * (1.0 / 3.0 - 0.5), 0.0).rgb +
+                textureSampleLevel(myTexture, mySampler, uv + dir * (2.0 / 3.0 - 0.5), 0.0).rgb
             );
             let rgbB = rgbA * 0.5 + 0.25 * (
-                textureSample(myTexture, mySampler, uv + dir * -0.5).rgb +
-                textureSample(myTexture, mySampler, uv + dir * 0.5).rgb
+                textureSampleLevel(myTexture, mySampler, uv + dir * -0.5, 0.0).rgb +
+                textureSampleLevel(myTexture, mySampler, uv + dir * 0.5, 0.0).rgb
             );
             let lumaB = dot(rgbB, vec3<f32>(0.299, 0.587, 0.114));
 
@@ -135,19 +135,19 @@ export const EnhancedPostProcessShaders = () => {
             let weight = 1.0 / 13.0;
             
             // 13-tap bloom (center + 12 samples)
-            bloom += textureSample(myTexture, mySampler, uv).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( spread, 0.0)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-spread, 0.0)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0,  spread)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0, -spread)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( spread,  spread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-spread,  spread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( spread, -spread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-spread, -spread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( spread * 1.5, 0.0)).rgb * weight * 0.5;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-spread * 1.5, 0.0)).rgb * weight * 0.5;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0,  spread * 1.5)).rgb * weight * 0.5;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0, -spread * 1.5)).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( spread, 0.0), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-spread, 0.0), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0,  spread), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0, -spread), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( spread,  spread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-spread,  spread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( spread, -spread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-spread, -spread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( spread * 1.5, 0.0), 0.0).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-spread * 1.5, 0.0), 0.0).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0,  spread * 1.5), 0.0).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0, -spread * 1.5), 0.0).rgb * weight * 0.5;
             
             // Threshold bloom
             let bloomLum = dot(bloom, vec3<f32>(0.299, 0.587, 0.114));
@@ -299,10 +299,10 @@ export const EnhancedPostProcessShaders = () => {
             let pulseG = pulse * 0.004;
             let pulseB = pulse * -0.018;
 
-            let baseSample = textureSample(myTexture, mySampler, finalUV);
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset)).r;
+            let baseSample = textureSampleLevel(myTexture, mySampler, finalUV, 0.0);
+            var r = textureSampleLevel(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset), 0.0).r;
             var g = baseSample.g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset)).b;
+            var b = textureSampleLevel(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset), 0.0).b;
             var color = vec3<f32>(r, g, b);
 
             // Add the shattered glass overlay into the final color

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -49,10 +49,10 @@ export const MaterialAwarePostProcessShaders = () => {
             let texelSize = vec2<f32>(1.0) / vec2<f32>(uniforms.screenWidth, uniforms.screenHeight);
 
             // Sample neighboring pixels (all sampling done unconditionally)
-            let nw = textureSample(myTexture, mySampler, uv + vec2<f32>(-texelSize.x, -texelSize.y)).rgb;
-            let ne = textureSample(myTexture, mySampler, uv + vec2<f32>( texelSize.x, -texelSize.y)).rgb;
-            let sw = textureSample(myTexture, mySampler, uv + vec2<f32>(-texelSize.x,  texelSize.y)).rgb;
-            let se = textureSample(myTexture, mySampler, uv + vec2<f32>( texelSize.x,  texelSize.y)).rgb;
+            let nw = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-texelSize.x, -texelSize.y), 0.0).rgb;
+            let ne = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( texelSize.x, -texelSize.y), 0.0).rgb;
+            let sw = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-texelSize.x,  texelSize.y), 0.0).rgb;
+            let se = textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( texelSize.x,  texelSize.y), 0.0).rgb;
 
             // Convert to luminance
             let lumaM = dot(texColor, vec3<f32>(0.299, 0.587, 0.114));
@@ -78,12 +78,12 @@ export const MaterialAwarePostProcessShaders = () => {
 
             // Sample along gradient (unconditional - avoids non-uniform control flow)
             let rgbA = 0.5 * (
-                textureSample(myTexture, mySampler, uv + dir * (1.0 / 3.0 - 0.5)).rgb +
-                textureSample(myTexture, mySampler, uv + dir * (2.0 / 3.0 - 0.5)).rgb
+                textureSampleLevel(myTexture, mySampler, uv + dir * (1.0 / 3.0 - 0.5), 0.0).rgb +
+                textureSampleLevel(myTexture, mySampler, uv + dir * (2.0 / 3.0 - 0.5), 0.0).rgb
             );
             let rgbB = rgbA * 0.5 + 0.25 * (
-                textureSample(myTexture, mySampler, uv + dir * -0.5).rgb +
-                textureSample(myTexture, mySampler, uv + dir * 0.5).rgb
+                textureSampleLevel(myTexture, mySampler, uv + dir * -0.5, 0.0).rgb +
+                textureSampleLevel(myTexture, mySampler, uv + dir * 0.5, 0.0).rgb
             );
             let lumaB = dot(rgbB, vec3<f32>(0.299, 0.587, 0.114));
 
@@ -150,7 +150,7 @@ export const MaterialAwarePostProcessShaders = () => {
             for (var y: i32 = -1; y <= 1; y++) {
                 for (var x: i32 = -1; x <= 1; x++) {
                     let sampleUV = uv + vec2<f32>(f32(x), f32(y)) * texelSize;
-                    let sampleColor = textureSample(myTexture, mySampler, sampleUV).rgb;
+                    let sampleColor = textureSampleLevel(myTexture, mySampler, sampleUV, 0.0).rgb;
                     let luma = dot(sampleColor, vec3<f32>(0.299, 0.587, 0.114));
                     lumaSum += luma;
                     lumaSqSum += luma * luma;
@@ -181,19 +181,19 @@ export const MaterialAwarePostProcessShaders = () => {
             let weight = 1.0 / 13.0;
             
             // 13-tap bloom (center + 12 samples)
-            bloom += textureSample(myTexture, mySampler, uv).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( adjustedSpread, 0.0)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread, 0.0)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0,  adjustedSpread)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0, -adjustedSpread)).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( adjustedSpread,  adjustedSpread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread,  adjustedSpread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( adjustedSpread, -adjustedSpread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread, -adjustedSpread) * 0.7).rgb * weight;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>( adjustedSpread * 1.5, 0.0)).rgb * weight * 0.5;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread * 1.5, 0.0)).rgb * weight * 0.5;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0,  adjustedSpread * 1.5)).rgb * weight * 0.5;
-            bloom += textureSample(myTexture, mySampler, uv + vec2<f32>(0.0, -adjustedSpread * 1.5)).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( adjustedSpread, 0.0), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread, 0.0), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0,  adjustedSpread), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0, -adjustedSpread), 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( adjustedSpread,  adjustedSpread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread,  adjustedSpread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( adjustedSpread, -adjustedSpread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread, -adjustedSpread) * 0.7, 0.0).rgb * weight;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>( adjustedSpread * 1.5, 0.0), 0.0).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(-adjustedSpread * 1.5, 0.0), 0.0).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0,  adjustedSpread * 1.5), 0.0).rgb * weight * 0.5;
+            bloom += textureSampleLevel(myTexture, mySampler, uv + vec2<f32>(0.0, -adjustedSpread * 1.5), 0.0).rgb * weight * 0.5;
             
             // Threshold bloom with material awareness
             let bloomLum = dot(bloom, vec3<f32>(0.299, 0.587, 0.114));
@@ -349,10 +349,10 @@ export const MaterialAwarePostProcessShaders = () => {
             let pulseG = pulse * 0.004;
             let pulseB = pulse * -0.018;
 
-            let baseSample = textureSample(myTexture, mySampler, finalUV);
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset)).r;
+            let baseSample = textureSampleLevel(myTexture, mySampler, finalUV, 0.0);
+            var r = textureSampleLevel(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset), 0.0).r;
             var g = baseSample.g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset)).b;
+            var b = textureSampleLevel(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset), 0.0).b;
             var color = vec3<f32>(r, g, b);
 
             // Add the shattered glass overlay into the final color

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -203,10 +203,10 @@ export const PostProcessShaders = () => {
             let pulseG = pulse * 0.004;
             let pulseB = pulse * -0.018;
 
-            let baseSample = textureSample(myTexture, mySampler, finalUV);
-            var r = textureSample(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset)).r;
+            let baseSample = textureSampleLevel(myTexture, mySampler, finalUV, 0.0);
+            var r = textureSampleLevel(myTexture, mySampler, finalUV + vec2<f32>(horizOffset + pulseR + chromaticMusicHoriz, vertAberration + pulseG * 0.6 + chromaticMusicOffset), 0.0).r;
             var g = baseSample.g;
-            var b = textureSample(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset)).b;
+            var b = textureSampleLevel(myTexture, mySampler, finalUV - vec2<f32>(horizOffset + pulseB + chromaticMusicHoriz, vertAberration + pulseR * 0.4 + chromaticMusicOffset), 0.0).b;
             let a = baseSample.a;
 
             // Bloom-ish boost (optimized 5-tap tent filter)
@@ -220,10 +220,10 @@ export const PostProcessShaders = () => {
             // 4 directional samples (cardinal directions for better cache coherence)
             let dX = vec2<f32>(spread, 0.0);
             let dY = vec2<f32>(0.0, spread);
-            glow += textureSample(myTexture, mySampler, finalUV + dX).rgb * 0.1875;
-            glow += textureSample(myTexture, mySampler, finalUV - dX).rgb * 0.1875;
-            glow += textureSample(myTexture, mySampler, finalUV + dY).rgb * 0.1875;
-            glow += textureSample(myTexture, mySampler, finalUV - dY).rgb * 0.1875;
+            glow += textureSampleLevel(myTexture, mySampler, finalUV + dX, 0.0).rgb * 0.1875;
+            glow += textureSampleLevel(myTexture, mySampler, finalUV - dX, 0.0).rgb * 0.1875;
+            glow += textureSampleLevel(myTexture, mySampler, finalUV + dY, 0.0).rgb * 0.1875;
+            glow += textureSampleLevel(myTexture, mySampler, finalUV - dY, 0.0).rgb * 0.1875;
 
             // Tuned bloom that preserves texture detail
             let glowLum = dot(glow, vec3<f32>(0.299, 0.587, 0.114));

--- a/tests/block-texture.test.ts
+++ b/tests/block-texture.test.ts
@@ -88,7 +88,7 @@ describe('block texture helpers', () => {
       addressModeV: 'clamp-to-edge',
       lodMinClamp: 0,
       lodMaxClamp: 4,
-      maxAnisotropy: 16,
+      maxAnisotropy: 4,
     });
   });
 

--- a/tests/texture-sampling.test.ts
+++ b/tests/texture-sampling.test.ts
@@ -48,7 +48,7 @@ describe('texture sampling WGSL generation', () => {
     it('uses color-signal-based gold/crystal separation by default', () => {
       const code = getSimpleTextureSamplingWGSL();
       expect(code).toContain('let goldSignal = texColor.r + texColor.g - texColor.b * 0.5');
-      expect(code).toContain('let metalMask = smoothstep(0.8, 1.2, goldSignal)');
+      expect(code).toContain('let metalMask = smoothstep(0.75, 1.2, goldSignal)');
     });
   });
 
@@ -158,12 +158,12 @@ describe('texture sampling WGSL generation', () => {
     it('updates material detection thresholds in generated code', () => {
       setBlockTextureConfig({
         materialDetectionMode: 'color_signal',
-        metalThresholdLow: 0.8,
+        metalThresholdLow: 0.75,
         metalThresholdHigh: 1.2,
       });
       const code = getSimpleTextureSamplingWGSL();
       // Should include the threshold values in the mask extraction
-      expect(code).toContain('smoothstep(0.8, 1.2, goldSignal)'); // low threshold
+      expect(code).toContain('smoothstep(0.75, 1.2, goldSignal)'); // low threshold
     });
   });
 });


### PR DESCRIPTION
This submission addresses weekly performance optimization and game feel polishing. I have performed the following updates:

- **WebGPU Shader Optimizations:** Converted dynamic `textureSample` calls inside loops and conditional post-processing paths to `textureSampleLevel` across `enhancedPostProcess.ts`, `materialAwarePostProcess.ts`, and `postProcess.ts`. This bypasses expensive and potentially invalid LOD computations within control flows, offering a smoother pipeline performance.
- **Image Sampled Block Quality:** Tweaked the geometry module by zooming `textureScale` to 0.99 to perfectly prevent atlas bleed. Lowered `maxAnisotropy` filtering from 16 to 4 to save GPU overhead while maintaining orthographic texture clarity. I also adjusted the glass vs metal extraction thresholds across multiple themes for sharper frame detection.
- **Game Feel Polish:** Expanded the input buffering constants (`MOVE_BUFFER_WINDOW` and `ROTATE_BUFFER_WINDOW`) to 40ms to accommodate minor frame hitching and prevent dropped inputs. Increased the "Coyote Time" grace period (by resetting the `lockTimer` to `-200`ms when dropping off ledges) for smoother gameplay logic.
- **Tests Passed:** Updated affected configuration threshold tests and confirmed full Vitest and AS build pipeline successes.

---
*PR created automatically by Jules for task [974743206573317759](https://jules.google.com/task/974743206573317759) started by @ford442*