### PR TITLE
Enhance Hard Drop Game Feel: Rotational Shake & Vertical Sparks

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -52,3 +52,5 @@
 - "Adding additive blending to the particle shader makes the explosions look like real light."
 - "Screen shake should decay exponentially, not linearly, for a snappier feel."
 - "Enhanced the chromatic aberration triggered by hard drops so it scales dynamically with the fall distance, making large drops feel incredibly heavy!"
+- "Added rotational camera shake to the existing translation shake to make hard drops feel even more visceral."
+- "Added upward-shooting vertical sparks on hard drops to sell the impact force."

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -500,6 +500,13 @@ export function onHardDrop(view: ViewEventHost, x: number, y: number, distance: 
     view.particleSystem.emitParticlesRadial(worldX, impactY, 0.0, angle, speed, burstColor);
   }
 
+  // Emit vertical sparks shooting up for extra juice
+  for (let i = 0; i < 20; i++) {
+    const upwardAngle = Math.PI * 1.5 + (Math.random() - 0.5) * 0.5; // Roughly upwards
+    const upwardSpeed = (30.0 + Math.random() * 40.0) * 2.0;
+    view.particleSystem.emitParticlesRadial(worldX, impactY, 0.0, upwardAngle, upwardSpeed, burstColor);
+  }
+
   triggerImpactEffects(view, worldX, impactY, distance);
 }
 

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -195,6 +195,11 @@ function updateCameraAndUniforms(view: WebGPUViewHost, _dt: number, time: number
   view._camEye[1] = camY; 
   view._camEye[2] = view.splitScreen?.active ? 98.0 : 75.0;
   
+  const angle = (Math.random() - 0.5) * 0.05 * view.visualEffects.shakeIntensity;
+  view._camUp[0] = Math.sin(angle);
+  view._camUp[1] = Math.cos(angle);
+  view._camUp[2] = 0.0;
+
   glMatrix.mat4.lookAt(view.VIEWMATRIX, view._camEye, view._camTarget, view._camUp);
   glMatrix.mat4.multiply(view.vpMatrix, view.PROJMATRIX, view.VIEWMATRIX);
   view.device.queue.writeBuffer(view.fragmentUniformBuffer, 16, view._camEye);


### PR DESCRIPTION
This PR further implements the "Neon Bricklayer" graphics engineer persona instructions by injecting more "JUICE" into the WebGPU renderer:

1. **Rotational Camera Shake:** Modified `updateCameraAndUniforms` in `src/webgpu/viewRenderLoop.ts`. On heavy impacts, the screen now physically tilts on the Z-axis (by altering the `_camUp` vector) instead of just shaking translationally.
2. **Vertical Impact Sparks:** In `src/webgpu/viewGameEvents.ts`, when a piece locks via a hard drop, it now shoots a tight cone of high-speed vertical sparks upwards, simulating debris bouncing off the locked blocks and selling the gravity of the slam.
3. **Journal Update:** Logged these changes into the `neon_bricklayers_journal.md` to satisfy the narrative tracking.

---
*PR created automatically by Jules for task [8665494776288327947](https://jules.google.com/task/8665494776288327947) started by @ford442*