### PR TITLE
Implement soft drop pressure graphics

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -472,19 +472,19 @@ export default class Controller {
             this.game.movePieceDown();
             this.recordReplay('down');
             this.playMoveSound('down');
-            this.viewWebGPU.visualEffects?.triggerGhostTrail?.(0.1);
-            this.viewWebGPU.visualEffects?.triggerMovementFlash?.(0.15);
+            // Remove heavy movement flash to let continuous soft drop take over
+            this.viewWebGPU.visualEffects?.triggerSoftDropPressure?.(0.2);
             if (this.game.activPiece && (this.viewWebGPU as any).particleSystem) {
                 const worldX = (this.game.activPiece.x + 1.5) * 2.2;
                 const worldY = (this.game.activPiece.y + 1.5) * -2.2;
-                for(let i = 0; i < 3; i++) {
-                    const spreadX = (Math.random() - 0.5) * 4.0;
-                    const spreadY = (Math.random() - 0.5) * 4.0;
+                for(let i = 0; i < 2; i++) {
+                    const spreadX = (Math.random() - 0.5) * 2.0;
+                    const spreadY = (Math.random() - 0.5) * 2.0;
                     (this.viewWebGPU as any).particleSystem.emitParticlesRadial(
                         worldX + spreadX, worldY + spreadY, 0.0,
                         Math.PI / 2 + (Math.random() - 0.5) * 0.5,
-                        10.0 + Math.random() * 15.0,
-                        [0.2, 0.8, 1.0, 0.6] // Cyan trail
+                        10.0 + Math.random() * 10.0,
+                        [0.2, 0.8, 1.0, 0.4] // Subtle cyan trail
                     );
                 }
             }
@@ -594,19 +594,19 @@ export default class Controller {
               this.game.movePieceDown();
               this.recordReplay('down');
               this.playMoveSound('down');
-              this.viewWebGPU.visualEffects?.triggerGhostTrail?.(0.1);
-              this.viewWebGPU.visualEffects?.triggerMovementFlash?.(0.15);
+              // Remove heavy movement flash to let continuous soft drop take over
+              this.viewWebGPU.visualEffects?.triggerSoftDropPressure?.(0.2);
             if (this.game.activPiece && (this.viewWebGPU as any).particleSystem) {
                 const worldX = (this.game.activPiece.x + 1.5) * 2.2;
                 const worldY = (this.game.activPiece.y + 1.5) * -2.2;
-                for(let i = 0; i < 3; i++) {
-                    const spreadX = (Math.random() - 0.5) * 4.0;
-                    const spreadY = (Math.random() - 0.5) * 4.0;
+                for(let i = 0; i < 2; i++) {
+                    const spreadX = (Math.random() - 0.5) * 2.0;
+                    const spreadY = (Math.random() - 0.5) * 2.0;
                     (this.viewWebGPU as any).particleSystem.emitParticlesRadial(
                         worldX + spreadX, worldY + spreadY, 0.0,
                         Math.PI / 2 + (Math.random() - 0.5) * 0.5,
-                        10.0 + Math.random() * 15.0,
-                        [0.2, 0.8, 1.0, 0.6] // Cyan trail
+                        10.0 + Math.random() * 10.0,
+                        [0.2, 0.8, 1.0, 0.4] // Subtle cyan trail
                     );
                 }
             }
@@ -807,7 +807,18 @@ export default class Controller {
       moveDown: () => {
         const prevY = this.game.activPiece.y;
         this.game.movePieceDown();
-        this.viewWebGPU.onMove?.(this.game.activPiece.x, this.game.activPiece.y);
+        // Replace heavy onMove flash spam with continuous soft drop pressure
+        this.viewWebGPU.visualEffects?.triggerSoftDropPressure?.(0.1);
+        if (this.game.activPiece && (this.viewWebGPU as any).particleSystem) {
+          const worldX = (this.game.activPiece.x + 1.5) * 2.2;
+          const worldY = (this.game.activPiece.y + 1.5) * -2.2;
+          (this.viewWebGPU as any).particleSystem.emitParticlesRadial(
+            worldX, worldY, 0.0,
+            Math.PI / 2 + (Math.random() - 0.5) * 0.5,
+            5.0 + Math.random() * 10.0,
+            [0.2, 0.8, 1.0, 0.4] // Very subtle cyan trail
+          );
+        }
         return prevY !== this.game.activPiece.y;
       },
       recordDownReplay: () => { this.recordReplay('down'); },

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -42,6 +42,10 @@ export class VisualEffects {
     movementFlashTimer: number = 0;
     lineClearFlashTimer: number = 0;
 
+    // Continuous soft-drop pressure (0..1)
+    softDropPressure: number = 0;
+    softDropActive: boolean = false;
+
     // Supernova Line Clear Laser state
     lineClearLaserY: Float32Array = new Float32Array([0.0, 0.0, 0.0, 0.0]);
     lineClearLaserIntensity: number = 0.0;
@@ -162,6 +166,12 @@ export class VisualEffects {
         this.lineClearFlashTimer *= 1.0 / (1.0 + dt * 4.0);
         if (this.lineClearFlashTimer < 0.01) this.lineClearFlashTimer = 0;
 
+        this.softDropPressure *= 1.0 / (1.0 + dt * 4.0); // slower decay than movement flash
+        if (this.softDropPressure < 0.01) {
+            this.softDropPressure = 0;
+            this.softDropActive = false;
+        }
+
         // Ghost trail decay (200ms window after moves)
         if (this.ghostTrailTimer > 0) this.ghostTrailTimer -= dt;
         if (this.ghostTrailTimer < 0) this.ghostTrailTimer = 0;
@@ -239,6 +249,12 @@ export class VisualEffects {
     triggerLineClearFlash(duration: number = 1.0): void {
         if (this.reducedMotion) return;
         this.lineClearFlashTimer = duration;
+    }
+
+    triggerSoftDropPressure(strength: number = 0.25): void {
+        if (this.reducedMotion) return;
+        this.softDropPressure = Math.min(1.0, this.softDropPressure + strength);
+        this.softDropActive = true;
     }
 
     triggerLock(duration: number = 0.3): void {

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -191,6 +191,13 @@ function updateCameraAndUniforms(view: WebGPUViewHost, _dt: number, time: number
   camX += view._shakeOffsetSmoothed.x;
   camY += view._shakeOffsetSmoothed.y;
 
+  // Add subtle wobble from soft drop pressure
+  if (view.visualEffects.softDropPressure > 0) {
+    const pressure = view.visualEffects.softDropPressure;
+    camX += Math.cos(time * 25.0) * pressure * 0.15;
+    camY += Math.sin(time * 30.0) * pressure * 0.15;
+  }
+
   view._camEye[0] = camX; 
   view._camEye[1] = camY; 
   view._camEye[2] = view.splitScreen?.active ? 98.0 : 75.0;
@@ -380,6 +387,11 @@ function updatePostProcessUniforms(view: WebGPUViewHost, time: number) {
   view._postProcessParams.neonBurst = view.neonBurstUniform ? view.neonBurstUniform[0] : 0.0;
   view._postProcessParams.saturationBoost = view.visualEffects.saturationBoost || 0.0;
   view._postProcessParams.chromaticIntensity = view.visualEffects.baseChromaticIntensity || 0.0;
+
+  // Add continuous soft drop pressure to chromatic intensity
+  if (view.visualEffects.softDropActive || view.visualEffects.softDropPressure > 0) {
+    view._postProcessParams.chromaticIntensity += view.visualEffects.softDropPressure * 0.4;
+  }
 
   // Compute board height fill ratio (0-1) for contracting danger vignette.
   // Uses highest occupied row (top = low index). No allocations in hot path.


### PR DESCRIPTION
Replaces the harsh, discrete visual flashes during soft drop with a smoother, continuous visual feedback. Soft drop pressure adds continuous chromatic aberration, slight camera wobble, and a sparse particle trail that decays gracefully when the user stops holding the down key.

---
*PR created automatically by Jules for task [15852616396994154546](https://jules.google.com/task/15852616396994154546) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added softer, continuous visual feedback while soft-dropping pieces, including subtle pressure effects and camera movement.
  - Added a neon burst and enhanced shockwave effect when performing a hard drop.
  - Improved post-processing feedback to make drop actions feel more responsive and dynamic.

- **Bug Fixes**
  - Soft-drop effects are now less intense, with reduced particle spread and duration for a cleaner visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->