### PR TITLE
feat: Neon Echo Trails for soft drops and movement

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -55,3 +55,4 @@
 - "Added rotational camera shake to the existing translation shake to make hard drops feel even more visceral."
 - "Added upward-shooting vertical sparks on hard drops to sell the impact force."
 - "Confirmed that the Shockwave distortion effect on Hard Drops, along with all associated JUICE (Warp Surge, Neon Burst, Chromatic Aberration, Bloom), are perfectly integrated and fully operational in the WebGPU pipeline and Game Logic."
+- "Added 'Neon Echo Trails' on piece movement and soft-drops. The trails use the holographic ghost shader path with additive cyan/magenta blending, decaying exponentially for a tactile, 'weighty neon' feel."

--- a/src/view/viewTypes.ts
+++ b/src/view/viewTypes.ts
@@ -88,6 +88,12 @@ export interface WebGPUViewHost extends ViewEventHost {
   _previousActivePiece: Piece | null;
   _hardDropBoostTimer: number;
   _shakeOffsetSmoothed: { x: number; y: number };
+  _lastEchoTrailX?: number;
+  _lastEchoTrailY?: number;
+  _lastEchoTrailTime?: number;
+  _lastEchoTrailX2?: number;
+  _lastEchoTrailY2?: number;
+  _lastEchoTrailTime2?: number;
   _f32_1: Float32Array;
   _f32_2: Float32Array;
   _f32_3: Float32Array;

--- a/src/webgpu/effects.ts
+++ b/src/webgpu/effects.ts
@@ -5,7 +5,18 @@
 
 import { renderLogger } from '../utils/logger.js';
 
+
+export interface EchoTrail {
+    x: number;
+    y: number;
+    blocks: number[][];
+    colorIdx: number;
+    age: number;
+    intensity: number;
+}
+
 export class VisualEffects {
+    echoTrails: EchoTrail[] = [];
     /** When true, skip shake / shockwave / flash / heavy FX (a11y). */
     reducedMotion = false;
 
@@ -141,6 +152,15 @@ export class VisualEffects {
         this.saturationBoost *= 1.0 / (1.0 + dt * 2.0);
         if (this.saturationBoost < 0.01) this.saturationBoost = 0;
 
+
+        // Update echo trails
+        for (let i = this.echoTrails.length - 1; i >= 0; i--) {
+            this.echoTrails[i].age += dt;
+            if (this.echoTrails[i].age > 0.22) {
+                this.echoTrails.splice(i, 1);
+            }
+        }
+
         // Glitch decay
         this.glitchIntensity *= 1.0 / (1.0 + dt * 3.0);
         if (this.glitchIntensity < 0.01) this.glitchIntensity = 0;
@@ -225,6 +245,15 @@ export class VisualEffects {
         }
 
         // Video crossfade animation is now managed by ReactiveVideoBackground
+    }
+
+
+    addEchoTrail(x: number, y: number, blocks: number[][], colorIdx: number, intensity: number = 1.0): void {
+        if (this.reducedMotion) return;
+        this.echoTrails.push({ x, y, blocks, colorIdx, age: 0, intensity });
+        if (this.echoTrails.length > 5) {
+            this.echoTrails.shift();
+        }
     }
 
     triggerFlash(duration: number = 1.0): void {

--- a/src/webgpu/viewPlayfield.ts
+++ b/src/webgpu/viewPlayfield.ts
@@ -301,7 +301,72 @@ export function renderPlayfieldBlocks(
     }
   }
 
+
+  // =========================================================================
+  // NEON ECHO TRAILS (Neon Bricklayer)
+  // Holographic movement and soft-drop trails
+  // =========================================================================
+  if (visualEffects?.echoTrails?.length) {
+    for (const trail of visualEffects.echoTrails) {
+      if (blockIndex >= uniformBindGroup_CACHE.length - 8) break;
+
+      const pieceW = trail.blocks[0]?.length || 0;
+      const pieceH = trail.blocks.length || 0;
+      const baseCol = currentTheme[trail.colorIdx] || currentTheme[1] || [0.9, 0.9, 0.9];
+
+      // True exponential decay matching effects.ts age logic
+      // Fade out fully by ~220ms
+      const decay = Math.exp(-trail.age * 15.0);
+      // Keep alpha low enough to trigger holographic 'isGhost' path in shader (<0.4)
+      const alpha = Math.min(0.38, 0.35 * decay * trail.intensity);
+
+      // Overbright cyan/magenta tint for "Neon" feel
+      const tintColor = trail.colorIdx % 2 === 0
+          ? [0.2, 0.9, 1.0] // Cyan
+          : [1.0, 0.2, 0.8]; // Magenta
+
+      const mixRatio = 0.6; // Mix base piece color with neon tint
+      const r = Math.min(2.0, (baseCol[0] * (1 - mixRatio) + tintColor[0] * mixRatio) * (1.5 + trail.intensity));
+      const g = Math.min(2.0, (baseCol[1] * (1 - mixRatio) + tintColor[1] * mixRatio) * (1.5 + trail.intensity));
+      const b = Math.min(2.0, (baseCol[2] * (1 - mixRatio) + tintColor[2] * mixRatio) * (1.5 + trail.intensity));
+
+      for (let ly = 0; ly < pieceH; ly++) {
+        for (let lx = 0; lx < pieceW; lx++) {
+          if (trail.blocks[ly][lx] === 0) continue;
+          if (blockIndex >= uniformBindGroup_CACHE.length) break;
+
+          _f32_4[0] = r; _f32_4[1] = g; _f32_4[2] = b; _f32_4[3] = alpha;
+
+          Matrix.mat4.identity(MODELMATRIX);
+          Matrix.mat4.identity(NORMALMATRIX);
+          _f32_3[0] = worldX(trail.x + lx);
+          _f32_3[1] = boardWorldY(trail.y + ly);
+          _f32_3[2] = 0.0;
+          Matrix.mat4.translate(MODELMATRIX, MODELMATRIX, _f32_3);
+
+          const trailBindGroup = uniformBindGroup_CACHE[blockIndex];
+          batchBuffer.set(vpMatrix as Float32Array, batchOffset);
+          batchBuffer.set(MODELMATRIX as Float32Array, batchOffset + 16);
+          batchBuffer.set(NORMALMATRIX as Float32Array, batchOffset + 32);
+          batchBuffer.set(_f32_4, batchOffset + 48);
+          // padding
+          batchBuffer[batchOffset + 52] = 0; batchBuffer[batchOffset + 53] = 0;
+          batchBuffer[batchOffset + 54] = 0; batchBuffer[batchOffset + 55] = 0;
+          batchBuffer[batchOffset + 56] = 0; batchBuffer[batchOffset + 57] = 0;
+          batchBuffer[batchOffset + 58] = 0; batchBuffer[batchOffset + 59] = 0;
+          batchBuffer[batchOffset + 60] = 0; batchBuffer[batchOffset + 61] = 0;
+          batchBuffer[batchOffset + 62] = 0; batchBuffer[batchOffset + 63] = 0;
+
+          uniformBindGroup_ARRAY[arrayLength++] = trailBindGroup;
+          blockIndex++;
+          batchOffset += 64;
+        }
+      }
+    }
+  }
+
   uniformBindGroup_ARRAY.length = arrayLength;
+
   return arrayLength;
 }
 

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -142,10 +142,55 @@ function updatePieceInterpolation(view: WebGPUViewHost, clampedDt: number) {
       view._previousActivePiece,
       view.state.activePiece,
     );
+
     view.visualX = r.x;
     view.visualY = r.y;
     view._previousActivePiece = r.prev;
-  } else {
+
+    // Trigger Neon Echo Trails
+    if (view.visualEffects && view.state.activePiece) {
+      if (view._lastEchoTrailX === undefined) view._lastEchoTrailX = view.state.activePiece.x;
+      if (view._lastEchoTrailY === undefined) view._lastEchoTrailY = view.state.activePiece.y;
+      if (view._lastEchoTrailTime === undefined) view._lastEchoTrailTime = 0;
+
+      const dx = Math.abs(view.state.activePiece.x - view._lastEchoTrailX);
+      const dy = Math.abs(view.state.activePiece.y - view._lastEchoTrailY);
+      const isSoftDropping = view.visualEffects.softDropActive;
+      const moved = dx >= 0.5 || dy >= 0.5;
+
+      if (moved && (isSoftDropping || dx > 0.1)) {
+        view._lastEchoTrailTime += clampedDt;
+        if (view._lastEchoTrailTime > 0.05) { // Limit trail emission rate
+          const combo = view.state.runStats?.peakCombo || 0;
+          const distanceBoost = Math.min(dy * 0.1, 1.0);
+          const intensity = 0.5 + (isSoftDropping ? 0.3 : 0.0) + (combo * 0.05) + distanceBoost;
+
+          let colorIdx = 4;
+          if (view.state.activePiece.blocks && view.state.activePiece.blocks.length > 0) {
+              const row = view.state.activePiece.blocks.find(r => r.some(c => c > 0));
+              if (row) {
+                  const val = row.find(c => c > 0);
+                  if (val) colorIdx = val;
+              }
+          }
+
+          view.visualEffects.addEchoTrail(
+            view._lastEchoTrailX,
+            view._lastEchoTrailY,
+            view.state.activePiece.blocks.map(row => [...row]),
+            colorIdx,
+            intensity
+          );
+
+          view._lastEchoTrailX = view.state.activePiece.x;
+          view._lastEchoTrailY = view.state.activePiece.y;
+          view._lastEchoTrailTime = 0;
+        }
+      } else if (!moved) {
+        view._lastEchoTrailX = view.state.activePiece.x;
+        view._lastEchoTrailY = view.state.activePiece.y;
+      }
+    }  } else {
     view._previousActivePiece = null;
   }
 


### PR DESCRIPTION
Implements the "Neon Echo Trails" visual effect requested by the user.

- **`src/webgpu/effects.ts`:** Introduced `EchoTrail` interface, state tracking, and age-based exponential decay logic to `VisualEffects`.
- **`src/webgpu/viewRenderLoop.ts`:** Added logic to detect significant movement or soft-dropping of the active piece, tracking last positions and emitting trails rate-limited by delta time. The intensity scales with `peakCombo` and movement distance.
- **`src/webgpu/viewPlayfield.ts`:** Hooked the trail states into the main `updatePlayfieldBindGroups` render loop. Renders fading trails with additive cyan/magenta blending utilizing the existing `isGhost` shader path in `pbrBlocks.ts` (triggered by `<0.4` alpha).
- **`neon_bricklayers_journal.md`:** Appended documentation of the effect implementation.
- Evaluated safety regarding GPU buffer size caps (`blockIndex >= uniformBindGroup_CACHE.length - 8`) and fixed a matrix reference aliasing bug inside the loop. Tests and Typechecking pass successfully.

---
*PR created automatically by Jules for task [9772263773917988145](https://jules.google.com/task/9772263773917988145) started by @ford442*