### PR TITLE
feat: Implement exponential decay for visual effects

### DIFF
--- a/src/viewWebGPU.ts
+++ b/src/viewWebGPU.ts
@@ -534,7 +534,10 @@ export default class View implements IView, ViewEventHost, WebGPUViewHost {
   render(dt: number) {
     // Decay Fresnel boost if any
     if (this.fresnelParams.hardDropBoost > 0) {
-      this.fresnelParams.hardDropBoost = Math.max(0, this.fresnelParams.hardDropBoost - dt * 2.0); // Simple decay
+      this.fresnelParams.hardDropBoost *= Math.exp(-dt * 10.0);
+      if (this.fresnelParams.hardDropBoost < 0.01) {
+        this.fresnelParams.hardDropBoost = 0;
+      }
     }
     if (this.device) {
       this.device.queue.writeBuffer(

--- a/src/webgpu/viewRenderLoop.ts
+++ b/src/webgpu/viewRenderLoop.ts
@@ -32,7 +32,7 @@ export function executeRenderLoop(view: WebGPUViewHost, dt: number) {
   if (view.state && view.state.effectFlag && view.state.effectCounter !== view.lastEffectCounter) {
     view.lastEffectCounter = view.state.effectCounter;
     view.shockwaveParamsUniform[0] = 1.0;
-    view._hardDropBoostTimer = 0.420; // 420ms
+
     if (typeof view.setFresnelBoost === 'function') {
       view.setFresnelBoost(1.0);
     }
@@ -47,13 +47,15 @@ export function executeRenderLoop(view: WebGPUViewHost, dt: number) {
 
   // Decay the neon burst (3x speed decay)
   if (view.neonBurstUniform && view.neonBurstUniform[0] > 0) {
-    view.neonBurstUniform[0] = Math.max(0, view.neonBurstUniform[0] - dt * 3.0);
+    view.neonBurstUniform[0] *= Math.exp(-dt * 10.0);
+    if (view.neonBurstUniform[0] < 0.01) {
+      view.neonBurstUniform[0] = 0.0;
+    }
   }
 
-  if (view._hardDropBoostTimer > 0) {
-    view._hardDropBoostTimer -= dt;
-    if (view._hardDropBoostTimer <= 0) {
-      view._hardDropBoostTimer = 0;
+  if (view.shockwaveParamsUniform && view.shockwaveParamsUniform[0] > 0) {
+    view.shockwaveParamsUniform[0] *= Math.exp(-dt * 10.0);
+    if (view.shockwaveParamsUniform[0] < 0.01) {
       view.shockwaveParamsUniform[0] = 0.0;
     }
   }


### PR DESCRIPTION
Updated visual effects to use mathematically correct exponential decay for a punchier "game feel", aligning with the Neon Bricklayer persona's requirement for snappier feedback.

- `src/webgpu/viewRenderLoop.ts`: Updated `shockwaveParamsUniform[0]` (used for `hardDropBoost`) and `neonBurstUniform[0]` to use `Math.exp(-dt * 10.0)` instead of linear timer deductions.
- `src/viewWebGPU.ts`: Updated `fresnelParams.hardDropBoost` to use exponential decay in the `render` cycle.
- Removed unused linear timer `_hardDropBoostTimer`.

---
*PR created automatically by Jules for task [4334776300141619532](https://jules.google.com/task/4334776300141619532) started by @ford442*