### PR TITLE
Enhance Hard Drop Fresnel and Add Particle Frustum Culling

### DIFF
--- a/src/view/viewTypes.ts
+++ b/src/view/viewTypes.ts
@@ -52,6 +52,7 @@ export interface ViewEventHost extends IView {
   lastEffectCounter: number;
   lastScore: number;
   neonBurstUniform?: Float32Array;
+  setFresnelBoost?(boost: number): void;
   game?: {
     getHighScoreManager?: () => HighScoreManager;
     getMode?: () => GameMode;

--- a/src/webgpu/compute.ts
+++ b/src/webgpu/compute.ts
@@ -200,6 +200,12 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
   p.pos += p.velocity * dt;
   p.life -= dt;
 
+  // Frustum / world-bounds cull — frees ring-buffer slots early
+  if (p.pos.y < -60.0 || abs(p.pos.z) > 40.0 || abs(p.pos.x - 10.0) > 35.0) {
+    p.life = -1.0;
+    p.scale = 0.0;
+  }
+
   // Scale animation
   // Poof out at death, Pop in at birth
   let normLife = p.life / p.maxLife;

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -458,6 +458,11 @@ export function onHardDrop(view: ViewEventHost, x: number, y: number, distance: 
   view.visualEffects.triggerParticleHit(2.0);
   if (view.neonBurstUniform) view.neonBurstUniform[0] = 1.0;
 
+  const fresnelBoost = 1.0 + Math.min(distance * 0.05, 0.8);
+  if (typeof view.setFresnelBoost === 'function') {
+    view.setFresnelBoost(fresnelBoost);
+  }
+
   // JUICE: Multiplied particle speeds and counts by 3.0x for heavier impact
   for (let i = 0; i < 450; i++) {
     const angle = (i / 450) * Math.PI * 2;


### PR DESCRIPTION
Added a distance-scaled Fresnel boost trigger explicitly in `onHardDrop` to increase edge glow intensity proportionally on heavier drops. Added bounding box frustum culling to the WGSL compute shader to kill particles that fall beyond the useful volume, maintaining performance during intense particle-heavy scenarios.

---
*PR created automatically by Jules for task [9854753749630113991](https://jules.google.com/task/9854753749630113991) started by @ford442*