### PR TITLE
Complete emsdk/WebGPU toolchain hardening foundation

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -87,7 +87,7 @@ Set **`TETRIS_CPP_WEBGPU`** before building:
 
 | Value | Behavior |
 |-------|----------|
-| `auto` (default) | Try `emdawnwebgpu` → `USE_WEBGPU` → Canvas2D-only |
+| `auto` (default) | Try `emdawnwebgpu` → Canvas2D-only on pinned emsdk ≥ 5.0; on older pins also tries legacy `USE_WEBGPU` before Canvas2D |
 | `emdawn` | Force `--use-port=emdawnwebgpu`, then Canvas2D fallback |
 | `legacy` | Force `-s USE_WEBGPU=1`, then Canvas2D fallback |
 | `none` | Canvas2D bootstrap only (`TETRIS_ENABLE_WEBGPU=0`) |
@@ -289,7 +289,7 @@ Release wasm size is recorded in `public/cpp/build-info.json` (`wasmBytes`, `jsB
 | emsdk | Typical linked port |
 |-------|---------------------|
 | 4.0.10 – 4.x | `--use-port=emdawnwebgpu` (tried first) or `-s USE_WEBGPU=1` if forced via `TETRIS_CPP_WEBGPU=legacy` |
-| 5.0.7+ (pinned) | `--use-port=emdawnwebgpu` — `-s USE_WEBGPU=1` is gone upstream, `auto` skips straight to it |
+| 5.0.7+ (pinned) | `--use-port=emdawnwebgpu` only — `-s USE_WEBGPU=1` is gone upstream, `auto` skips it intentionally |
 | no GPU headers | Canvas2D-only (stubs) |
 
 ## Loading from TypeScript

--- a/scripts/build-cpp.mjs
+++ b/scripts/build-cpp.mjs
@@ -84,6 +84,22 @@ function readPinnedEmsdkVersion() {
   return line || null;
 }
 
+/** Major version of a dotted semver string (e.g. "5.0.7" → 5). */
+function semverMajor(version) {
+  const match = version?.match(/^(\d+)/);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+/**
+ * Legacy `-s USE_WEBGPU=1` was removed upstream around the emsdk 5.0 line.
+ * When the repo pin is ≥ 5.0, `auto` should not waste a failed link on it.
+ */
+function shouldSkipLegacyWebGpu() {
+  const pinned = readPinnedEmsdkVersion();
+  const major = semverMajor(pinned);
+  return major != null && major >= 5;
+}
+
 function hasEmcc() {
   const probe = spawnSync('emcc', ['--version'], { encoding: 'utf8' });
   return probe.status === 0;
@@ -136,6 +152,9 @@ function resolveWebGpuAttempts() {
       return ['NONE'];
     case 'auto':
     default:
+      if (shouldSkipLegacyWebGpu()) {
+        return ['EMDAWN', 'NONE'];
+      }
       return ['EMDAWN', 'USE_WEBGPU', 'NONE'];
   }
 }
@@ -388,6 +407,12 @@ function main() {
   }
 
   warnEmsdkDrift();
+  if (WEBGPU_ENV === 'auto' && shouldSkipLegacyWebGpu()) {
+    console.log(
+      '[build-cpp] pinned emsdk >= 5.0 — skipping legacy -s USE_WEBGPU=1 (removed upstream); ' +
+      'use TETRIS_CPP_WEBGPU=legacy to force on older toolchains'
+    );
+  }
   console.log(`[build-cpp] Building ${MODE} → ${OUT_JS}`);
   console.log(`[build-cpp] TETRIS_CPP_WEBGPU=${WEBGPU_ENV}`);
   console.log(`[build-cpp] Flags: ${getOptFlags().join(' ')}`);

--- a/tests/build-cpp.test.ts
+++ b/tests/build-cpp.test.ts
@@ -17,15 +17,29 @@ describe('build-cpp outputs', () => {
     expect(src).toContain('compile_commands.json');
     expect(src).toContain('SAFE_HEAP');
     expect(src).toContain('wasmBytes');
+    expect(src).toContain('jsBytes');
+    expect(src).toContain('shouldSkipLegacyWebGpu');
   });
 
   it('auto WebGPU port order tries emdawnwebgpu before the removed legacy flag', () => {
     const src = readFileSync(join(ROOT, 'scripts/build-cpp.mjs'), 'utf8');
-    const match = src.match(/case 'auto':\s*\n\s*default:\s*\n\s*return \[([^\]]+)\];/);
+    const match = src.match(/case 'auto':\s*\n\s*default:\s*\n\s*if \(shouldSkipLegacyWebGpu\(\)\) \{\s*\n\s*return \[([^\]]+)\];\s*\n\s*\}\s*\n\s*return \[([^\]]+)\];/);
     expect(match).not.toBeNull();
-    const order = match![1].split(',').map((s) => s.trim().replace(/'/g, ''));
-    expect(order.indexOf('EMDAWN')).toBeLessThan(order.indexOf('USE_WEBGPU'));
-    expect(order[order.length - 1]).toBe('NONE');
+    const pinnedOrder = match![1].split(',').map((s) => s.trim().replace(/'/g, ''));
+    const fallbackOrder = match![2].split(',').map((s) => s.trim().replace(/'/g, ''));
+    expect(pinnedOrder).toEqual(['EMDAWN', 'NONE']);
+    expect(fallbackOrder.indexOf('EMDAWN')).toBeLessThan(fallbackOrder.indexOf('USE_WEBGPU'));
+    expect(fallbackOrder[fallbackOrder.length - 1]).toBe('NONE');
+  });
+
+  it('skips legacy USE_WEBGPU when pinned emsdk is 5.x', () => {
+    const pinned = readFileSync(join(ROOT, '.emsdk-version'), 'utf8').trim();
+    const major = Number.parseInt(pinned.split('.')[0], 10);
+    const src = readFileSync(join(ROOT, 'scripts/build-cpp.mjs'), 'utf8');
+    expect(src).toContain('shouldSkipLegacyWebGpu');
+    if (major >= 5) {
+      expect(src).toContain("major >= 5");
+    }
   });
 
   it('enforces a release wasm size budget', () => {

--- a/tests/gpu-context.test.ts
+++ b/tests/gpu-context.test.ts
@@ -4,6 +4,7 @@ import {
   selectOptionalFeatures,
   requestGpuAdapterAndDevice,
   resolveRequiredLimits,
+  buildCanvasConfiguration,
   REQUIRED_GPU_LIMITS,
   DESIRED_OPTIONAL_FEATURES,
 } from '../src/webgpu/gpuContext.js';
@@ -68,6 +69,19 @@ describe('selectOptionalFeatures', () => {
   it('tolerates a throwing has()', () => {
     const bad = { has() { throw new Error('boom'); } };
     expect(selectOptionalFeatures(bad)).toEqual([]);
+  });
+});
+
+describe('buildCanvasConfiguration', () => {
+  it('uses premultiplied alpha and an explicit empty viewFormats list', () => {
+    const device = {} as GPUDevice;
+    const config = buildCanvasConfiguration(device, 'bgra8unorm');
+    expect(config).toEqual({
+      device,
+      format: 'bgra8unorm',
+      alphaMode: 'premultiplied',
+      viewFormats: [],
+    });
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Most of the toolchain + device-policy foundation from the 2026-07-22 audit landed in #457. This PR closes the remaining gap: **`TETRIS_CPP_WEBGPU=auto` no longer attempts the removed legacy `-s USE_WEBGPU=1` flag when `.emsdk-version` is ≥ 5.0**, so a clean `npm run cpp:release` on the pinned emsdk links `emdawnwebgpu` without a wasted failed link.

Also adds a `buildCanvasConfiguration` unit test and aligns `cpp/README.md` with the actual auto port order on the pinned toolchain.

## Acceptance checklist

- [x] `.emsdk-version` is **5.0.7** (matches CI cache key + `cpp/README.md`)
- [x] `auto` prefers `emdawnwebgpu`; on pinned 5.x, legacy is **skipped intentionally** (logged)
- [x] `build-info.json` emits `wasmBytes`/`jsBytes`; `cpp-renderer.yml` CI asserts both
- [x] `requestGpuAdapterAndDevice` has `requiredLimits`, centralized `buildCanvasConfiguration`, `GameSettings.gpuPower` wiring — covered by `tests/gpu-context.test.ts`
- [x] `"type": "module"` in `package.json` — ESLint runs clean

## Changes in this PR

- `scripts/build-cpp.mjs`: `shouldSkipLegacyWebGpu()` — when pin major ≥ 5, `auto` → `['EMDAWN', 'NONE']` with an explanatory log line
- `tests/build-cpp.test.ts`: assert skip logic + `jsBytes` contract
- `tests/gpu-context.test.ts`: `buildCanvasConfiguration` premultiplied-alpha test
- `cpp/README.md`: document auto behavior on pinned 5.x

## Not in scope (deferred)

- C++ `WGPUPresentMode_Mailbox` experiment for high-end — still `Fifo` + premultiplied; can follow once shader parity work resumes
- Replacing emdawn with Rust wgpu (research already decided against)

## Test plan

- [x] `npm test` (213 tests)
- [x] `npm run lint` (no `MODULE_TYPELESS_PACKAGE_JSON` warning)
- [ ] `npm run cpp:release` on emsdk 5.0.7 → `webGpuBackendId: "emdawn"` with no legacy attempt (CI `cpp-renderer.yml`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16368e06-582d-412d-8f2a-1761b25f623a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16368e06-582d-412d-8f2a-1761b25f623a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

