### PR TITLE
feat: cap max global particles to 5000

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -57,3 +57,4 @@
 - "Confirmed that the Shockwave distortion effect on Hard Drops, along with all associated JUICE (Warp Surge, Neon Burst, Chromatic Aberration, Bloom), are perfectly integrated and fully operational in the WebGPU pipeline and Game Logic."
 - "Added 'Neon Echo Trails' on piece movement and soft-drops. The trails use the holographic ghost shader path with additive cyan/magenta blending, decaying exponentially for a tactile, 'weighty neon' feel."
 - 'Added an intense Glitch effect on Tetris line clears to make big plays feel even more chaotic and impactful.'
+- "Capped max global particles in the WebGPU renderer strictly to 5000 in `particleBudgetForQuality()` to ensure heavy explosive effects don't lag the browser, fulfilling the Neon Bricklayer performance verification clause."

--- a/public/assets/video/manifest.json
+++ b/public/assets/video/manifest.json
@@ -6,5 +6,5 @@
     "bg3.mp4"
   ],
   "generated": false,
-  "builtAt": "2026-07-19T00:54:54.609Z"
+  "builtAt": "2026-07-31T00:38:48.011Z"
 }

--- a/src/webgpu/particles/layout.ts
+++ b/src/webgpu/particles/layout.ts
@@ -35,9 +35,13 @@ export const PARTICLE_BUDGET: Record<QualityPreset, number> = {
 };
 
 export function particleBudgetForQuality(quality: SettingsQuality): number {
-  if (quality === 'custom') return PARTICLE_BUDGET.medium;
-  if (quality in PARTICLE_BUDGET) return PARTICLE_BUDGET[quality as QualityPreset];
-  return PARTICLE_BUDGET.medium;
+  let budget = PARTICLE_BUDGET.medium;
+  if (quality === 'custom') {
+    budget = PARTICLE_BUDGET.medium;
+  } else if (quality in PARTICLE_BUDGET) {
+    budget = PARTICLE_BUDGET[quality as QualityPreset];
+  }
+  return Math.min(budget, 5000);
 }
 
 /** CPU staging row layout (float index within one particle). */


### PR DESCRIPTION
Implemented a strict limit of 5000 on the max global particles to prevent potential lag during explosive visual effects, in line with the "Neon Bricklayer" persona's performance guidelines.

---
*PR created automatically by Jules for task [4186936212885832433](https://jules.google.com/task/4186936212885832433) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * WebGPU particle effects are now capped at 5,000 particles to help maintain performance during heavy effects.
  * Unrecognized or custom quality settings now fall back to a balanced particle budget.

* **Chores**
  * Updated asset build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->