### PR TITLE
feat: Enhance block pulse effect based on game level

### DIFF
--- a/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
+++ b/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
@@ -397,8 +397,9 @@
             }
 
             // Gentle emissive pulse (main.ts uses 0.25 scale to avoid washout)
-            let idlePulse = sin(time * 3.0) * 0.5 + 0.5;
-            let emissivePulse = idlePulse * 0.25 + fUniforms.movementFlash * 0.4 + fUniforms.lineClearFlash * 0.8;
+            let levelPulseSpeed = 3.0 + fUniforms.level * 0.5;
+            let idlePulse = sin(time * levelPulseSpeed) * 0.5 + 0.5;
+            let emissivePulse = idlePulse * (0.25 + min(fUniforms.level * 0.03, 0.5)) + fUniforms.movementFlash * 0.4 + fUniforms.lineClearFlash * 0.8;
             finalColor += finalColor * emissivePulse;
 
             // Lava-specific magma glow: slow pulsing + bubbling variation (cooling magma look)


### PR DESCRIPTION
- Replaced static block pulse calculations in WGSL with dynamic scaling based on `fUniforms.level`.
- Increased both the speed and the intensity of the pulse as the level goes up, fulfilling the "Neon Bricklayer" persona's requirement for a dynamic "Pulse" effect that makes blocks feel alive.

---
*PR created automatically by Jules for task [7571866484001570726](https://jules.google.com/task/7571866484001570726) started by @ford442*