### PR TITLE
Fix glass block translucency: use CPU uniforms and auto-detect block.png layout

### DIFF
--- a/src/webgpu/blockTexture.ts
+++ b/src/webgpu/blockTexture.ts
@@ -256,6 +256,31 @@ export function resetBlockTextureConfig(): void {
 }
 
 /**
+ * Pick atlas vs single-tile crop based on authored image dimensions.
+ * go.1ink.us uses a 768×768 single tile; this repo's default atlas is 2816×1536.
+ * Wrong subregion coords on a single tile crop a corner sliver and break glass masks.
+ */
+export function applyBlockTextureConfigForImageDimensions(width: number, height: number): void {
+  const maxDim = Math.max(width, height);
+  if (maxDim >= 2000) {
+    setBlockTextureConfig({ ...DEFAULT_BLOCK_TEXTURE_CONFIG });
+    return;
+  }
+
+  setBlockTextureConfig({
+    ...SINGLE_TILE_TEXTURE_CONFIG,
+    subregionX: 0,
+    subregionY: 0,
+    subregionWidth: 1,
+    subregionHeight: 1,
+    subregionInset: 0.04,
+    materialDetectionMode: 'warmth',
+    metalThresholdLow: 0.75,
+    metalThresholdHigh: 1.15,
+  });
+}
+
+/**
  * Generate atlas sampling parameters for WGSL shaders
  * Returns shader-compatible string values for the current config
  */

--- a/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
+++ b/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
@@ -271,12 +271,13 @@
                     finalColor += vec3f(0.4, 0.65, 0.95) * edge3 * glassMask * 0.35;
                 }
 
-                // Opaque gold frame; stained-glass window stays readable over the video portal.
+                // Gold frame opaque; glass center opacity from CPU (reserved2.xy = min/max, .z = Fresnel power).
                 let edgeFresnel = 1.0 - NdotV;
-                let fresnelSq = edgeFresnel * edgeFresnel;
-                let glassMin = 0.82;
-                let glassMax = 0.97;
-                let glassOpacity = mix(glassMin, glassMax, fresnelSq);
+                let glassMin = fUniforms.reserved2.x;
+                let glassMax = fUniforms.reserved2.y;
+                let glassPower = max(fUniforms.reserved2.z, 0.001);
+                let glassFresnel = pow(edgeFresnel, glassPower);
+                let glassOpacity = mix(glassMin, glassMax, glassFresnel);
                 finalAlpha = mix(1.0, glassOpacity, glassMaskAlpha);
             } else if (fUniforms.enablePBR < 0.5 || materialType == 0u) {
                 // Classic mode

--- a/src/webgpu/viewPipelines.ts
+++ b/src/webgpu/viewPipelines.ts
@@ -25,6 +25,7 @@ import {
   createBlockTextureBindingView,
   setBlockTextureConfig,
   getBlockTextureConfig,
+  applyBlockTextureConfigForImageDimensions,
 } from './blockTexture.js';
 import {
   BLOCK_TILE_EXTRACT_SCALE,
@@ -78,6 +79,8 @@ export async function loadBlockTexture(view: any): Promise<void> {
         reject(new Error(`Failed to load ${textureUrl}`));
       };
     });
+
+    applyBlockTextureConfigForImageDimensions(img.width, img.height);
 
     // Authored tile is uploaded as a SINGLE texture, so the shader uses SINGLE mode.
     setBlockTextureConfig({ samplingMode: 'single' });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`test.1ink.us/tetris-webgpu` blocks looked much less translucent than `go.1ink.us/tetris` — not because of PHP, htaccess, or UTF-16 encoding.

## Root causes

1. **Shader ignored CPU glass tuning** — `fragmentMain.wgsl` hardcoded `glassMin=0.82` / `glassMax=0.97` while `viewMaterials.ts` writes artist-tunable values (default ~0.30–0.78) into `FragmentUniforms.reserved2`. Glass centers stayed ~82–97% opaque, so the video portal barely showed through.

2. **Different deployed assets** — `go.1ink.us` serves a **768×768** `block.png` (~1 MB) loaded as a single tile. `test.1ink.us` serves the **2816×1536** atlas (~6.5 MB) with subregion extraction. Same Apache COOP/COEP headers on both hosts; PNGs are served as binary `image/png`.

3. **Wrong crop if atlas coords used on a single tile** — subregion defaults target the middle tile of the 2816 atlas. Applying them to a 768 image crops a corner sliver and breaks metal/glass mask baking.

## Fix

- Read `glassMin`, `glassMax`, and Fresnel power from `fUniforms.reserved2` in the authored sampling path.
- `applyBlockTextureConfigForImageDimensions()` picks atlas vs full-image crop based on image size before tile extraction.

## Testing

- `npm test` — 213 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b9c70cb-e781-4560-a440-767a26629725?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b9c70cb-e781-4560-a440-767a26629725&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved block texture handling for both large and small images, including automatic sizing and sampling adjustments.
  * Enhanced glass rendering with configurable opacity and Fresnel effects.

* **Bug Fixes**
  * Improved texture configuration selection based on the loaded image dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->