### PR TITLE
feat(graphics): add dynamic particle rotation to WGSL shader

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -58,3 +58,4 @@
 - "Added 'Neon Echo Trails' on piece movement and soft-drops. The trails use the holographic ghost shader path with additive cyan/magenta blending, decaying exponentially for a tactile, 'weighty neon' feel."
 - 'Added an intense Glitch effect on Tetris line clears to make big plays feel even more chaotic and impactful.'
 - "Capped max global particles in the WebGPU renderer strictly to 5000 in `particleBudgetForQuality()` to ensure heavy explosive effects don't lag the browser, fulfilling the Neon Bricklayer performance verification clause."
+- "Added Dynamic Particle Rotation in the WGSL particle shader! Explosions and hard drops now look much more chaotic and impactful as the debris spins and rotates dynamically based on its lifetime, rather than just being static quads stretched along velocity."

--- a/public/assets/video/manifest.json
+++ b/public/assets/video/manifest.json
@@ -6,5 +6,5 @@
     "bg3.mp4"
   ],
   "generated": false,
-  "builtAt": "2026-07-31T00:38:48.011Z"
+  "builtAt": "2026-08-02T00:14:41.552Z"
 }

--- a/src/webgpu/shaders/particle.ts
+++ b/src/webgpu/shaders/particle.ts
@@ -43,6 +43,15 @@ export const ParticleShaders = () => {
             else if (cornerIdx == 4u) { pos = vec2<f32>( 1.0, -1.0); uv = vec2<f32>(1.0, 0.0); }
             else if (cornerIdx == 5u) { pos = vec2<f32>( 1.0,  1.0); uv = vec2<f32>(1.0, 1.0); }
 
+            // JUICE: Dynamic Particle Rotation (Spinning debris)
+            // Add a rotation matrix to the particle based on its life and spatial position
+            let rotSpeed = 15.0; // Spin rate
+            let rotOffset = particlePos.x * 12.9898 + particlePos.y * 78.233; // Pseudo-random starting angle
+            let rotAngle = rotOffset + particleLife * rotSpeed;
+            let s = sin(rotAngle);
+            let c = cos(rotAngle);
+            pos = vec2<f32>(pos.x * c - pos.y * s, pos.x * s + pos.y * c);
+
             // Velocity Stretching (Neon Sparks)
             // If particle is moving fast, stretch it along the velocity vector
             let speed = sqrt(dot(particleVel, particleVel));


### PR DESCRIPTION
Implements dynamic particle rotation in the WebGPU particle shader, allowing particles to spin as they age. This improves the visual 'juice' of the game by making explosive effects (like hard drops and line clears) feel more chaotic and less like static quads stretching along velocity. Logged the enhancement in the Neon Bricklayer's Journal. All tests, linting, and builds pass.

---
*PR created automatically by Jules for task [13551061000570180373](https://jules.google.com/task/13551061000570180373) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Particle debris now rotates dynamically throughout its lifetime, creating more natural and visually engaging effects.
  * Rotation responds to each particle’s movement and position while preserving velocity-based stretching.

* **Documentation**
  * Added a journal entry documenting the updated particle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->