### PR TITLE
Add Danger Vignette visual effect

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -60,3 +60,4 @@
 - "Capped max global particles in the WebGPU renderer strictly to 5000 in `particleBudgetForQuality()` to ensure heavy explosive effects don't lag the browser, fulfilling the Neon Bricklayer performance verification clause."
 - "Added Dynamic Particle Rotation in the WGSL particle shader! Explosions and hard drops now look much more chaotic and impactful as the debris spins and rotates dynamically based on its lifetime, rather than just being static quads stretched along velocity."
 - "Implemented 'Combo Escalation': Passed a continuous 'comboEnergy' value from Game Logic into the WebGPU pipeline! As the player's combo count grows, the background parallax speed exponentially accelerates, the global ambient pulse intensifies, and the blocks themselves throb with escalating neon emissive energy!"
+- "Added Danger Vignette that pulses red when the board is full to both enhanced and material-aware post processing passes."

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -346,6 +346,22 @@ export const EnhancedPostProcessShaders = () => {
             let vignette = 1.0 - clamp((distFromCenterSq - vignetteInnerRadiusSq) / (vignetteOuterSq - vignetteInnerRadiusSq), 0.0, 1.0);
             color *= vignette;
 
+            // Danger vignette: screen-edge red that contracts (inner radius shrinks) as board fills (u_dangerLevel)
+            // Pulses opacity at 2 Hz (sin(time * 4 * PI)) only when dangerLevel > 0.75
+            let danger = uniforms.dangerLevel;
+            if (danger > 0.01) {
+                let dangerInner = 0.28 - danger * 0.26; // contracts toward 0.02 when full (deeper red encroachment)
+                let dangerOuter = 1.35;
+                let dangerVig = clamp((distFromCenterSq - dangerInner) / (dangerOuter - dangerInner), 0.0, 1.0);
+                let red = vec3<f32>(0.55, 0.04, 0.04); // deep red
+                let dangerOpacity = danger * 0.9;
+                if (danger > 0.75) {
+                    let pulse = 0.5 + 0.5 * sin(uniforms.time * 12.56637); // exactly 2 Hz
+                    dangerOpacity *= (0.55 + 0.45 * pulse);
+                }
+                color = mix(color, red, dangerVig * dangerOpacity);
+            }
+
             // Warp Surge Flash
             if (uniforms.warpSurge > 0.01) {
                 let invert = vec3<f32>(1.0) - color;

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -397,6 +397,22 @@ export const MaterialAwarePostProcessShaders = () => {
             let vignette = 1.0 - clamp((distFromCenterSq - vignetteInnerRadiusSq) / (vignetteOuterSq - vignetteInnerRadiusSq), 0.0, 1.0);
             color *= vignette;
 
+            // Danger vignette: screen-edge red that contracts (inner radius shrinks) as board fills (u_dangerLevel)
+            // Pulses opacity at 2 Hz (sin(time * 4 * PI)) only when dangerLevel > 0.75
+            let danger = uniforms.dangerLevel;
+            if (danger > 0.01) {
+                let dangerInner = 0.28 - danger * 0.26; // contracts toward 0.02 when full (deeper red encroachment)
+                let dangerOuter = 1.35;
+                let dangerVig = clamp((distFromCenterSq - dangerInner) / (dangerOuter - dangerInner), 0.0, 1.0);
+                let red = vec3<f32>(0.55, 0.04, 0.04); // deep red
+                let dangerOpacity = danger * 0.9;
+                if (danger > 0.75) {
+                    let pulse = 0.5 + 0.5 * sin(uniforms.time * 12.56637); // exactly 2 Hz
+                    dangerOpacity *= (0.55 + 0.45 * pulse);
+                }
+                color = mix(color, red, dangerVig * dangerOpacity);
+            }
+
             // Warp Surge Flash
             if (uniforms.warpSurge > 0.01) {
                 let invert = vec3<f32>(1.0) - color;

--- a/src/webgpu/shaders/postProcess.ts
+++ b/src/webgpu/shaders/postProcess.ts
@@ -272,7 +272,7 @@ export const PostProcessShaders = () => {
             if (danger > 0.01) {
                 let dangerInner = 0.28 - danger * 0.26; // contracts toward 0.02 when full (deeper red encroachment)
                 let dangerOuter = 1.35;
-                let dangerVig = 1.0 - clamp((distFromCenterSq - dangerInner) / (dangerOuter - dangerInner), 0.0, 1.0);
+                let dangerVig = clamp((distFromCenterSq - dangerInner) / (dangerOuter - dangerInner), 0.0, 1.0);
                 let red = vec3<f32>(0.55, 0.04, 0.04); // deep red
                 let dangerOpacity = danger * 0.9;
                 if (danger > 0.75) {


### PR DESCRIPTION
Added a 'Danger Vignette' visual effect that pulses red at the screen edges when the board is nearly full.
This enhances the game feel (JUICE) by providing a clear, escalating visual cue of impending danger, while maintaining clarity by only encroaching from the edges. 
The implementation ensures consistency across all three post-processing paths (standard, enhanced, and material-aware), and fixes a prior logic error in the standard post-process shader where the vignette was inverted.

---
*PR created automatically by Jules for task [8377958866827226259](https://jules.google.com/task/8377958866827226259) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a red danger vignette effect that intensifies as the board fills.
  * The effect contracts toward the screen center as danger increases.
  * Added a pulsing animation at high danger levels for enhanced visual feedback.

* **Bug Fixes**
  * Corrected the danger overlay’s spatial distribution so it appears in the intended screen areas.

* **Documentation**
  * Added a journal entry documenting the danger vignette effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->