### PR TITLE
Enhance image sampled blocks to be more translucent and glass-like

### DIFF
--- a/patch_wgsl.js
+++ b/patch_wgsl.js
@@ -1,4 +1,0 @@
-import fs from 'fs';
-let code = fs.readFileSync('src/webgpu/shaders/wgsl/block/fragmentMain.wgsl', 'utf8');
-code = code.replace(/let fresnel = pow\(rimPower, fresnelParams.fresnelPower\);/g, 'let f2 = rimPower * rimPower; let fresnel = f2 * f2 * rimPower; // approximated pow(rimPower, 5.0)');
-fs.writeFileSync('src/webgpu/shaders/wgsl/block/fragmentMain.wgsl', code);

--- a/public/assets/video/manifest.json
+++ b/public/assets/video/manifest.json
@@ -6,5 +6,5 @@
     "bg3.mp4"
   ],
   "generated": false,
-  "builtAt": "2026-08-03T04:11:47.469Z"
+  "builtAt": "2026-08-05T00:12:01.740Z"
 }

--- a/src/webgpu/blockTexture.ts
+++ b/src/webgpu/blockTexture.ts
@@ -198,8 +198,8 @@ export const DEFAULT_BLOCK_TEXTURE_CONFIG: BlockTextureConfig = {
   useProceduralFallback: true,
   maskChannel: 'auto',
   // Reference curve matching block.png gold frame + crystal interior.
-  authoredGlassMin: 0.30,
-  authoredGlassMax: 0.78,
+  authoredGlassMin: 0.15,
+  authoredGlassMax: 0.70,
   authoredGlassFresnelPower: 2.0,
 
   // Extractor heuristic defaults
@@ -218,8 +218,8 @@ export const SINGLE_TILE_TEXTURE_CONFIG: BlockTextureConfig = {
   metalThresholdLow: 0.40,
   metalThresholdHigh: 0.55,
   useProceduralFallback: true,
-  authoredGlassMin: 0.30,
-  authoredGlassMax: 0.78,
+  authoredGlassMin: 0.15,
+  authoredGlassMax: 0.70,
   authoredGlassFresnelPower: 2.0,
 
   // Extractor heuristic defaults

--- a/src/webgpu/materials.ts
+++ b/src/webgpu/materials.ts
@@ -156,8 +156,8 @@ export const Materials: Record<string, Material> = {
     clearcoat: 0.1,
     anisotropic: 0.0,
     dispersion: 0.0,
-    authoredGlassMin: 0.38,
-    authoredGlassMax: 0.78,
+    authoredGlassMin: 0.15,
+    authoredGlassMax: 0.70,
     authoredGlassFresnelPower: 2.0,
   },
 

--- a/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
+++ b/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
@@ -269,6 +269,14 @@
                     let edgeFresnel = 1.0 - NdotV;
                     let edge3 = edgeFresnel * edgeFresnel * edgeFresnel;
                     finalColor += vec3f(0.4, 0.65, 0.95) * edge3 * glassMask * 0.35;
+
+                    // NEON BRICKLAYER: Environment Refraction for authored glass
+                    let refractDir = refract(-V, N, 1.0 / 1.15); // Approximate IOR for glass
+                    let refractEnv = proceduralEnvReflect(refractDir, time);
+                    let glassTint = mix(vec3f(0.92, 0.96, 1.0), vColor.rgb, 0.22);
+                    let refractedColor = refractEnv * glassTint;
+                    finalColor = mix(finalColor, refractedColor, glassMask * 0.45); // Mix in refraction
+
                 }
 
                 // Gold frame opaque; glass center opacity from CPU (reserved2.xy = min/max, .z = Fresnel power).


### PR DESCRIPTION
Improved the "JUICE" of the image sampled blocks by enhancing their glass-like visual properties.

- Lowered base glass opacity (`authoredGlassMin` from 0.30/0.38 to 0.15, `authoredGlassMax` from 0.78 to 0.70).
- Added an environment refraction calculation to the `useAuthoredSampling` block shader path to simulate realistic glass light bending.

---
*PR created automatically by Jules for task [8655165164921342192](https://jules.google.com/task/8655165164921342192) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based glass refraction with tinted blending for more realistic glass rendering.

* **Improvements**
  * Reduced glass opacity ranges for block and image-based materials, creating a clearer appearance.
  * Refreshed the video asset manifest timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->