### PR TITLE
Optimize WebGPU texture mask sharpen with 5-tap pattern

### DIFF
--- a/jules_plan.md
+++ b/jules_plan.md
@@ -77,3 +77,10 @@ This document outlines the optimizations and game-feel improvements made in the 
   * In the background shader, `comboEnergy` escalates parallax scrolling speed and global ambient pulses.
   * In the block shader, `comboEnergy` intensifies and accelerates the core neon block breathing pulse.
 * **Metrics**: Converts integer-based discrete combo events into a smooth, decaying continuous shader driver, making high-combo plays feel frantically 'juiced'.
+
+### 10. Shader Mask Sharpening Optimization (Texture Fetch Reduction)
+**Objective**: Reduce the number of texture fetches per fragment in the hot path.
+* **Files**: `src/webgpu/shaders/wgsl/block/fragmentMain.wgsl`
+* **Changes**:
+  * Optimized the mask sharpening sampling pass from an expensive 3x3 (9-tap) `textureSampleLevel` lookup to a 5-tap cross pattern (center, up, down, left, right).
+* **Metrics**: Saves 4 texture fetches per fragment across the entire playfield during PBR block rendering, substantially reducing memory bandwidth overhead while maintaining mask sharpness.

--- a/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
+++ b/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
@@ -83,19 +83,14 @@
                 let texel = 1.0 / max(dims, vec2<f32>(1.0));
                 let r = texel * 1.0;
 
-                let a0 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>(-r.x, -r.y), 0.0).a;
                 let a1 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( 0.0, -r.y), 0.0).a;
-                let a2 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( r.x, -r.y), 0.0).a;
+                let a2 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( 0.0,  r.y), 0.0).a;
                 let a3 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>(-r.x,  0.0), 0.0).a;
-                let a4 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( 0.0,  0.0), 0.0).a;
-                let a5 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( r.x,  0.0), 0.0).a;
-                let a6 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>(-r.x,  r.y), 0.0).a;
-                let a7 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( 0.0,  r.y), 0.0).a;
-                let a8 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( r.x,  r.y), 0.0).a;
+                let a4 = textureSampleLevel(blockTexture, blockSampler, texUV + vec2<f32>( r.x,  0.0), 0.0).a;
 
                 metalSoftBaked = max(
                     metalSoftBaked0,
-                    max(a0, max(a1, max(a2, max(a3, max(a4, max(a5, max(a6, max(a7, a8))))))))
+                    max(a1, max(a2, max(a3, a4)))
                 );
             }
 


### PR DESCRIPTION
Reduces WebGPU texture sampling overhead by optimizing the mask sharpening max-pool logic to use a 5-tap cross pattern instead of a 9-tap box pattern.

---
*PR created automatically by Jules for task [4667675055535152286](https://jules.google.com/task/4667675055535152286) started by @ford442*