### PR TITLE
Add Neon Hyper-Inversion and Black Hole triggers on Tetris clears

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -548,6 +548,9 @@ export default class Game implements ModeGameHooks {
             result.linesCleared.push(linesScore[i]);
         }
         result.tSpin = wasTSpin;
+        if (linesScore.length >= 4) {
+            this.neonHyperInversionFlag = true;
+        }
         this.triggerLineClearReactive(linesScore.length, this.combo, wasTSpin, isAllClear);
         if (wasTSpin) this.triggerTSpinReactive('normal');
         if (isAllClear) this.view?.onPerfectClearReactive?.();

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -249,6 +249,7 @@ export function onLineClear(view: ViewEventHost, lines: number[], tSpin: boolean
         const uvY = 0.5 - (worldY - camY) / visibleHeight;
         view.visualEffects.triggerShockwave([0.5, uvY], 0.4, 0.2, 0.1, 3.0);
         view.visualEffects.triggerGlitch(1.0);
+        view.visualEffects.triggerBlackHole([0.5, uvY]);
       }
     }
   });


### PR DESCRIPTION
These changes fulfill the visual spectacle requests from "The Neon Bricklayer", specifically adding the missing triggers for the 'Neon Hyper-Inversion' and 'Black Hole' post-processing effects on Tetris (4-line) clears to enhance the visual impact of big plays.

---
*PR created automatically by Jules for task [14243235656717429542](https://jules.google.com/task/14243235656717429542) started by @ford442*