### PR TITLE
feat: trigger shockwave on hard drop

### DIFF
--- a/public/assets/video/manifest.json
+++ b/public/assets/video/manifest.json
@@ -6,5 +6,5 @@
     "bg3.mp4"
   ],
   "generated": false,
-  "builtAt": "2026-08-07T00:46:17.720Z"
+  "builtAt": "2026-08-12T00:05:27.730Z"
 }

--- a/src/webgpu/viewGameEvents.ts
+++ b/src/webgpu/viewGameEvents.ts
@@ -427,6 +427,10 @@ export function onHardDrop(view: ViewEventHost, x: number, y: number, distance: 
   const worldX = x * 2.2;
   const startRow = y - distance;
 
+  if (view.visualEffects && distance > 0) {
+    triggerImpactEffects(view, worldX, y * -2.2, distance);
+  }
+
   if (loadGameSettings().ghostDropTrail && view.visualEffects && distance > 0) {
     const snap = view.game?.getHardDropSnapshot?.();
     if (snap) {


### PR DESCRIPTION
Added `triggerImpactEffects` call inside `onHardDrop` in `src/webgpu/viewGameEvents.ts` to execute the spatial shockwave and camera shake logic whenever a block is hard dropped, adhering to the "Neon Bricklayer" visual instructions.

---
*PR created automatically by Jules for task [9740196156996921559](https://jules.google.com/task/9740196156996921559) started by @ford442*