### PR TITLE
Add visual spectacle enhancements to shaders

### DIFF
--- a/neon_bricklayers_journal.md
+++ b/neon_bricklayers_journal.md
@@ -61,3 +61,4 @@
 - "Added Dynamic Particle Rotation in the WGSL particle shader! Explosions and hard drops now look much more chaotic and impactful as the debris spins and rotates dynamically based on its lifetime, rather than just being static quads stretched along velocity."
 - "Implemented 'Combo Escalation': Passed a continuous 'comboEnergy' value from Game Logic into the WebGPU pipeline! As the player's combo count grows, the background parallax speed exponentially accelerates, the global ambient pulse intensifies, and the blocks themselves throb with escalating neon emissive energy!"
 - "Added Danger Vignette that pulses red when the board is full to both enhanced and material-aware post processing passes."
+- "Modified filmGrain in post processing shaders to scale with dangerLevel, creating a tactile TV static failure effect when nearing top-out."

--- a/src/webgpu/shaders/enhancedPostProcess.ts
+++ b/src/webgpu/shaders/enhancedPostProcess.ts
@@ -84,7 +84,7 @@ export const EnhancedPostProcessShaders = () => {
         fn filmGrain(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
             let time = uniforms.time;
             let grain = fract(sin(uv.x * 12.9898 + uv.y * 78.233 + time) * 43758.5453);
-            let grainAmount = 0.03;
+            let grainAmount = 0.03 + (uniforms.dangerLevel * 0.15); // JUICE: Increase grain when near top-out
             let grainSize = 1.5;
             let noise = (grain - 0.5) * grainAmount;
             return color + noise * (1.0 - color) * grainSize;

--- a/src/webgpu/shaders/materialAwarePostProcess.ts
+++ b/src/webgpu/shaders/materialAwarePostProcess.ts
@@ -97,7 +97,7 @@ export const MaterialAwarePostProcessShaders = () => {
         fn filmGrain(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {
             let time = uniforms.time;
             let grain = fract(sin(uv.x * 12.9898 + uv.y * 78.233 + time) * 43758.5453);
-            let grainAmount = 0.03;
+            let grainAmount = 0.03 + (uniforms.dangerLevel * 0.15); // JUICE: Increase grain when near top-out
             let grainSize = 1.5;
             let noise = (grain - 0.5) * grainAmount;
             return color + noise * (1.0 - color) * grainSize;

--- a/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
+++ b/src/webgpu/shaders/wgsl/block/fragmentMain.wgsl
@@ -386,7 +386,7 @@
             // NEW: Apply particle-material interaction
             let particleIntensity = fUniforms.particleIntensity;
             if (particleIntensity > 0.0) {
-                var pMatType = materialType;
+                var pMatType = fUniforms.particleMaterialType;
                 // If using authored PBR texture (type 0), infer from masks
                 if (pMatType == 0u && fUniforms.enablePBR > 0.5) {
                     if (glassMask > 0.5) {


### PR DESCRIPTION
- Replaced `materialType` with `fUniforms.particleMaterialType` in `fragmentMain.wgsl` for accurate particle-material interactions (glass refraction ripples, gold/chrome specular flashes).
- Dynamically scaled film grain intensity (`grainAmount`) with `uniforms.dangerLevel` in both `materialAwarePostProcess.ts` and `enhancedPostProcess.ts` to create an intense TV static failure effect when nearing top-out.
- Logged the dynamic film grain effect to `neon_bricklayers_journal.md`.

---
*PR created automatically by Jules for task [6207755178832985187](https://jules.google.com/task/6207755178832985187) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Film grain effects now intensify as danger rises, creating stronger TV-static visuals near top-out.
* **Bug Fixes**
  * Particle effects now use their correct material type for more accurate visual interactions.
  * Existing material texture detection remains supported for authored visuals.
* **Documentation**
  * Added a journal entry documenting the danger-responsive film grain behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->